### PR TITLE
keyboard improvements

### DIFF
--- a/include/nds/arm9/keyboard.h
+++ b/include/nds/arm9/keyboard.h
@@ -64,7 +64,7 @@ typedef enum
 typedef struct KeyMap {
 	const u16* mapDataPressed;	/*!< the map for keys pressed*/
 	const u16* mapDataReleased;	/*!< the map for keys released */
-	const int* keymap; 			/*!< the lookup table for x y grid location to corresponding key */
+	const s16* keymap; 			/*!< the lookup table for x y grid location to corresponding key */
 	int width; 					/*!< width of the keyboard in grid spaces */
 	int height; 				/*!< height of the keyboard in grid spaces*/
 }KeyMap;
@@ -162,7 +162,7 @@ void keyboardHide(void);
 	\param y the pixel y location
 	\return the key pressed or NOKEY if user pressed outside the keypad
 */
-int keyboardGetKey(int x, int y);
+s16 keyboardGetKey(int x, int y);
 
 /*!	\brief reads the input until a the return key is pressed or the maxLen is exceeded.
 	\param buffer a buffer to hold the input string
@@ -173,13 +173,13 @@ void keyboardGetString(char * buffer, int maxLen);
 /*!	\brief Waits for user to press a key and returns the key pressed.
 	Use keyboardUpdate instead for async operation.
 */
-int keyboardGetChar(void);
+s16 keyboardGetChar(void);
 
 /*!	\brief Processes the keyboard.
 	Should be called once per frame when using the keyboard in an async manner.
 	\return the ascii code of the key pressed or -1 if no key was pressed.
 */
-int keyboardUpdate(void);
+s16 keyboardUpdate(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* Use 16-bit instead of 32-bit keymap indices.
  * The only used indices, in practice, are a small set of values < 0 (DVK_* defines) and values 0-255 (the range of a `char`). Given that the DS's bottom display doesn't even have 65536 pixels total, 16-bit should be more than enough.
  * This saves 640 bytes of ROM space for the default keyboard.
* Remove unused key buffer if NO_DEVOPTAB is defined.
  * The key buffer is only used if `keyboardRead` is present, which is not used alongside libsysnds (which prefers `keyboardUpdate`). As such, it is removed, removing backspace functionality in edge cases but saving ~260 bytes of RAM.
* Resolve bounds check TODO, and fix a bug in handling non-32-wide keymaps while at it.