### PR TITLE
add SCFG/NDMA register definitions

### DIFF
--- a/include/nds.h
+++ b/include/nds.h
@@ -60,6 +60,7 @@
  - \ref memory.h "General memory definitions"
  - \ref memory.h "nds and gba header structure"
  - \ref dma.h "Direct Memory Access"
+ - \ref ndma.h "DSi New Direct Memory Access"
 
  \section system_api System
  - \ref ndstypes.h "Custom DS types"
@@ -248,6 +249,7 @@ extern "C" {
 #include "nds/input.h"
 #include "nds/sha1.h"
 
+#include "nds/ndma.h"
 
 //---------------------------------------------------------------------------------
 #ifdef ARM9

--- a/include/nds/dma.h
+++ b/include/nds/dma.h
@@ -64,12 +64,12 @@ dmaCopy(source, destination, sizeof(dataToCopy));
 #define DMA3_CR        (*(vuint32*)0x040000DC)
 
 
-#define DMA_SRC(n)     (*(vuint32*)(0x040000B0+(n*12)))
-#define DMA_DEST(n)    (*(vuint32*)(0x040000B4+(n*12)))
-#define DMA_CR(n)      (*(vuint32*)(0x040000B8+(n*12)))
+#define DMA_SRC(n)     (*(vuint32*)(0x040000B0+((n)*12)))
+#define DMA_DEST(n)    (*(vuint32*)(0x040000B4+((n)*12)))
+#define DMA_CR(n)      (*(vuint32*)(0x040000B8+((n)*12)))
 
 #ifdef ARM9
-#define DMA_FILL(n)    (*(vuint32*)(0x040000E0+(n*4)))
+#define DMA_FILL(n)    (*(vuint32*)(0x040000E0+((n)*4)))
 #endif
 
 // DMA control register contents

--- a/include/nds/ndma.h
+++ b/include/nds/ndma.h
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------
+
+	Copyright (C) 2005, 2023
+		Jason Rogers (dovoto)
+		Dave Murphy (WinterMute)
+		Adrian Siekierka (asie)
+
+	This software is provided 'as-is', without any express or implied
+	warranty.  In no event will the authors be held liable for any
+	damages arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any
+	purpose, including commercial applications, and to alter it and
+	redistribute it freely, subject to the following restrictions:
+
+	1.	The origin of this software must not be misrepresented; you
+		must not claim that you wrote the original software. If you use
+		this software in a product, an acknowledgment in the product
+		documentation would be appreciated but is not required.
+
+	2.	Altered source versions must be plainly marked as such, and
+		must not be misrepresented as being the original software.
+
+	3.	This notice may not be removed or altered from any source
+		distribution.
+
+---------------------------------------------------------------------------------*/
+
+#ifndef NDS_NDMA_INCLUDE
+#define NDS_NDMA_INCLUDE
+
+#include "nds/ndstypes.h"
+
+#define NDMA_GCR	(*(vuint32*)0x04004100)
+
+#define NDMA_GCR_DELAY_SCALER(n)	((n) << 16)
+#define NDMA_GCR_ROUND_ROBIN		BIT(31)
+
+#define NDMA0_SRC	(*(vuint32*)0x04004104)
+#define NDMA0_DEST	(*(vuint32*)0x04004108)
+#define NDMA0_LENGTH	(*(vuint32*)0x0400410C)
+#define NDMA0_BLENGTH	(*(vuint32*)0x04004110)
+#define NDMA0_BDELAY	(*(vuint32*)0x04004114)
+#define NDMA0_FILL	(*(vuint32*)0x04004118)
+#define NDMA0_CR	(*(vuint32*)0x0400411C)
+
+#define NDMA1_SRC	(*(vuint32*)0x04004120)
+#define NDMA1_DEST	(*(vuint32*)0x04004124)
+#define NDMA1_LENGTH	(*(vuint32*)0x04004128)
+#define NDMA1_BLENGTH	(*(vuint32*)0x0400412C)
+#define NDMA1_BDELAY	(*(vuint32*)0x04004130)
+#define NDMA1_FILL	(*(vuint32*)0x04004134)
+#define NDMA1_CR	(*(vuint32*)0x04004138)
+
+#define NDMA2_SRC	(*(vuint32*)0x0400413C)
+#define NDMA2_DEST	(*(vuint32*)0x04004140)
+#define NDMA2_LENGTH	(*(vuint32*)0x04004144)
+#define NDMA2_BLENGTH	(*(vuint32*)0x04004148)
+#define NDMA2_BDELAY	(*(vuint32*)0x0400414C)
+#define NDMA2_FILL	(*(vuint32*)0x04004150)
+#define NDMA2_CR	(*(vuint32*)0x04004154)
+
+#define NDMA3_SRC	(*(vuint32*)0x04004158)
+#define NDMA3_DEST	(*(vuint32*)0x0400415C)
+#define NDMA3_LENGTH	(*(vuint32*)0x04004160)
+#define NDMA3_BLENGTH	(*(vuint32*)0x04004164)
+#define NDMA3_BDELAY	(*(vuint32*)0x04004168)
+#define NDMA3_FILL	(*(vuint32*)0x0400416C)
+#define NDMA3_CR	(*(vuint32*)0x04004170)
+
+#define NDMA_SRC(n)	(*(vuint32*)0x04004104+((n)*0x1C))
+#define NDMA_DEST(n)	(*(vuint32*)0x04004108+((n)*0x1C))
+#define NDMA_LENGTH(n)	(*(vuint32*)0x0400410C+((n)*0x1C))
+#define NDMA_BLENGTH(n)	(*(vuint32*)0x04004110+((n)*0x1C))
+#define NDMA_BDELAY(n)	(*(vuint32*)0x04004114+((n)*0x1C))
+#define NDMA_FILL(n)	(*(vuint32*)0x04004118+((n)*0x1C))
+#define NDMA_CR(n)	(*(vuint32*)0x0400411C+((n)*0x1C))
+
+#define NDMA_BDELAY_CYCLES(n)	(n)
+#define NDMA_BDELAY_DIV_1	(0)
+#define NDMA_BDELAY_DIV_4	(1<<16)
+#define NDMA_BDELAY_DIV_16	(2<<16)
+#define NDMA_BDELAY_DIV_64	(3<<16)
+
+#define NDMA_ENABLE	BIT(31)
+#define NDMA_BUSY	BIT(31)
+#define NDMA_IRQ_REQ	BIT(30)
+#define NDMA_REPEAT	BIT(29)
+
+#define NDMA_BLOCK_SCALER(n)	((n) << 16)
+
+#define NDMA_SRC_INC	(0)
+#define NDMA_SRC_DEC	(1<<13)
+#define NDMA_SRC_FIX	(2<<13)
+#define NDMA_SRC_FILL	(3<<13)
+
+#define NDMA_DST_INC	(0)
+#define NDMA_DST_DEC	(1<<10)
+#define NDMA_DST_FIX	(2<<13)
+
+#define NDMA_START_NOW		(1<<28)
+#define NDMA_START_TIMER0	(0)
+#define NDMA_START_TIMER1	(1<<24)
+#define NDMA_START_TIMER2	(2<<24)
+#define NDMA_START_TIMER3	(3<<24)
+#define NDMA_START_TIMER(n)	((n) << 24)
+#define NDMA_START_CARD		(4<<24)
+#define NDMA_START_VBL		(6<<24)
+
+#ifdef ARM9
+#define NDMA_START_HBL		(7<<24)
+#define NDMA_START_LINE		(8<<24)
+// TODO: NDMA mode 0x09?
+#define NDMA_START_FIFO		(10<<24)
+#define NDMA_START_CAMERA	(11<<24)
+#endif
+
+#ifdef ARM7
+#define NDMA_START_NTR_WIFI	(7<<24)
+#define NDMA_START_SDMMC	(8<<24)
+#define NDMA_START_TWL_WIFI	(9<<24)
+#define NDMA_START_AES_IN	(10<<24)
+#define NDMA_START_AES_OUT	(11<<24)
+#define NDMA_START_MIC		(12<<24)
+#endif
+
+static inline 
+/*! \fn ndmaBusy(uint8 channel)
+\brief determines if the specified NDMA channel is busy
+\param channel the NDMA channel to check (0 - 3).  
+\return non zero if busy, 0 if channel is free
+*/
+int ndmaBusy(uint8 channel) {
+	return (NDMA_CR(channel) & NDMA_BUSY)>>31;
+}
+
+#endif
+

--- a/include/nds/system.h
+++ b/include/nds/system.h
@@ -68,18 +68,6 @@ typedef enum
 */
 #define	REG_POWERCNT	*(vu16*)0x4000304
 
-#define REG_SCFG_ROM		*(vu16*)0x4004000
-
-#ifdef ARM7
-#define REG_SCFG_A9ROM		*(vu8*)0x4004000
-#define REG_SCFG_A7ROM		*(vu8*)0x4004001  // ??
-#endif
-
-#define REG_SCFG_CLK		*(vu16*)0x4004004
-#define REG_SCFG_RST		*(vu16*)0x4004006
-#define REG_SCFG_EXT		*(vu32*)0x4004008
-#define REG_SCFG_MC			*(vu16*)0x4004010
-
 static inline
 /*!
 	\brief sets the Y trigger(?)
@@ -446,6 +434,72 @@ void resetARM7(u32 address);
 
 #ifdef ARM7
 void resetARM9(u32 address);
+#endif
+
+// DSi SCFG registers
+
+#define REG_SCFG_ROM		*(vu16*)0x4004000
+#define REG_SCFG_CLK		*(vu16*)0x4004004
+#define REG_SCFG_RST		*(vu16*)0x4004006
+#define REG_SCFG_EXT		*(vu32*)0x4004008
+#define REG_SCFG_MC		*(vu16*)0x4004010
+
+#ifdef ARM7
+#define REG_SCFG_A9ROM		*(vu8*)0x4004000
+#define REG_SCFG_A7ROM		*(vu8*)0x4004001
+
+#define SCFG_CLK_SDMMC		BIT(0)
+#define SCFG_CLK_MBK_RAM	BIT(7)
+#define SCFG_CLK_TOUCH		BIT(8)
+
+#define SCFG_EXT_DMA		IT(0)
+#define SCFG_EXT_SOUND_DMA	BIT(1)
+#define SCFG_EXT_SOUND		BIT(2)
+#define SCFG_EXT_CARD		BIT(7)
+#define SCFG_EXT_INTERRUPT	BIT(8)
+#define SCFG_EXT_SPI		BIT(9)
+#define SCFG_EXT_SOUND_DMA_EXT	BIT(10)
+#define SCFG_EXT_LCD		BIT(12)
+#define SCFG_EXT_VRAM		BIT(13)
+#define SCFG_EXT_RAM_DEBUG	BIT(14)
+#define SCFG_EXT_RAM_TWL	BIT(15)
+#define SCFG_EXT_NDMA		BIT(16)
+#define SCFG_EXT_AES		BIT(17)
+#define SCFG_EXT_SDMMC		BIT(18)
+#define SCFG_EXT_WIFI_SDIO	BIT(19)
+#define SCFG_EXT_MIC		BIT(20)
+#define SCFG_EXT_SNDEXCNT	BIT(21)
+#define SCFG_EXT_I2C		BIT(22)
+#define SCFG_EXT_GPIO		BIT(23)
+#define SCFG_EXT_MBK_RAM	BIT(25)
+#define SCFG_EXT_SCFG_MBK_REG	BIT(31)
+#endif
+
+#ifdef ARM9
+#define SCFG_CLK_ARM9_TWL	BIT(0)
+#define SCFG_CLK_DSP		BIT(1)
+#define SCFG_CLK_CAMERA_IF	BIT(2)
+#define SCFG_CLK_MBK_RAM	BIT(7)
+#define SCFG_CLK_CAMERA_EXT	BIT(8)
+
+#define SCFG_RST_DSP		BIT(0)
+
+#define SCFG_EXT_DMA		BIT(0)
+#define SCFG_EXT_GEOMETRY	BIT(1)
+#define SCFG_EXT_RENDERER	BIT(2)
+#define SCFG_EXT_2D		BIT(3)
+#define SCFG_EXT_DIVIDER	BIT(4)
+#define SCFG_EXT_CARD		BIT(7)
+#define SCFG_EXT_INTERRUPT	BIT(8)
+#define SCFG_EXT_LCD		BIT(12)
+#define SCFG_EXT_VRAM		BIT(13)
+#define SCFG_EXT_RAM_DEBUG	BIT(14)
+#define SCFG_EXT_RAM_TWL	BIT(15)
+#define SCFG_EXT_NDMA		BIT(16)
+#define SCFG_EXT_CAMERA		BIT(17)
+#define SCFG_EXT_DSP		BIT(18)
+#define SCFG_EXT_MBK_RAM	BIT(25)
+#define SCFG_EXT_SCFG_MBK_REG	BIT(31)
 #endif
 
 #endif


### PR DESCRIPTION
This may help you start adding NDMA integrations to DSi-specific things. Also fixes a minor macro bug in `dma.h`. Tried to hold to existing naming conventions, especially in `ndma.h`. 