### PR TITLE
interrupts: add DSi interrupts, code improvements

### DIFF
--- a/source/arm7/clock.c
+++ b/source/arm7/clock.c
@@ -275,7 +275,7 @@ void initClockIRQ() {
 //---------------------------------------------------------------------------------
 
 	REG_RCNT = 0x8100;
-	irqSet(IRQ_NETWORK, syncRTC);
+	irqSet(IRQ_RTC, syncRTC);
 	// Reset the clock if needed
 	rtcReset();
 


### PR DESCRIPTION
* Do not provide ARM7/ARM9-specific definitions on the other CPU.
* Add definitions for (most) DSi-specific interrupts.
* Add IRQ_DMA and IRQ_NDMA, to match IRQ_TIMER.
* Increase the size of the main IRQ table and decrease the size of the auxillary IRQ table to match newly required counts.
* Actually initialize the auxillary IRQ table to match the main IRQ table.
* Add IRQ_RTC synonym to replace IRQ_NETWORK. [Personal pet peeve](https://github.com/asiekierka/uxnds/issues/3), it led to confusion when working with ARM7 code. Would benefit from a matching replacement in the default ARM7 examples.

Untested; might benefit from a quick power-on test on a DSi to see if it still boots fine.