### PR TITLE
Fix several EEPROM bugs

### DIFF
--- a/source/common/cardEeprom.c
+++ b/source/common/cardEeprom.c
@@ -79,7 +79,7 @@ int cardEepromGetType(void) {
 	if (( sr == 0xff && id == 0xffffff) || ( sr == 0 && id == 0 )) return -1;
 	if ( sr == 0xf0 && id == 0xffffff ) return 1;
 	if ( sr == 0x00 && id == 0xffffff ) return 2;
-	if ( id != 0xffffff) return 3;
+	if ( id != 0xffffff || ( sr == 0x02 && id == 0xffffff )) return 3;
 	
 	return 0;
 }
@@ -97,22 +97,35 @@ uint32 cardEepromGetSize() {
 	if(type == 1)
 		return 512;
 	if(type == 2) {
-		u32 buf1,buf2,buf3;
+		u32 buf1,buf2,buf3 = 0x54534554; // "TEST"
+		// Save the first word of the EEPROM
 		cardReadEeprom(0,(u8*)&buf1,4,type);
-		if ( !(buf1 != 0 || buf1 != 0xffffffff) ) {
-			buf3 = ~buf1;
-			cardWriteEeprom(0,(u8*)&buf3,4,type);
-		} else {
-			buf3 = buf1;
-		}
-		int size = 8192;
-		while (1) {	 
-			cardReadEeprom(size,(u8*)&buf2,4,type);
-			if ( buf2 == buf3 ) break;
-			size += 8192;
-		};
 
-		if ( buf1 != buf3 ) cardWriteEeprom(0,(u8*)&buf1,4,type);
+		// Write "TEST" to it
+		cardWriteEeprom(0,(u8*)&buf3,4,type);
+
+		// Loop until the EEPROM mirrors and the first word shows up again
+		int size = 8192;
+		while (1) {
+			cardReadEeprom(size,(u8*)&buf2,4,type);
+			// Check if it matches, if so check again with another value to ensure no false positives
+			if (buf2 == buf3) {
+				u32 buf4 = 0x74736574; // "test"
+				// Write "test" to the first word
+				cardWriteEeprom(0,(u8*)&buf4,4,type);
+
+				// Check if it still matches
+				cardReadEeprom(size,(u8*)&buf2,4,type);
+				if (buf2 == buf4) break;
+
+				// False match, write "TEST" back and keep going
+				cardWriteEeprom(0,(u8*)&buf3,4,type);
+			}
+			size += 8192;
+		}
+
+		// Restore the first word
+		cardWriteEeprom(0,(u8*)&buf1,4,type);
 
 		return size;
 	}
@@ -150,8 +163,22 @@ uint32 cardEepromGetSize() {
 
 		if ( ((id >> 16) & 0xff) == 0xC2 ) { // Macronix
 			
-			if (device == 0x2211)
+			switch(device) {
+
+			case 0x2211:
 				return 128*1024;		//	1Mbit(128KByte) - MX25L1021E
+				break;
+			case 0x2017:
+				return 8*1024*1024;		//	64Mbit(8 meg)
+				break;
+			}
+		}
+
+		if (id == 0xffffff) {
+			int sr = cardEepromCommand(SPI_EEPROM_RDSR);
+			if (sr == 2) { // Pokémon Mystery Dungeon - Explorers of Sky
+				return 128*1024; // 1Mbit (128KByte)
+			}
 		}
 		
 

--- a/source/common/cardEeprom.c
+++ b/source/common/cardEeprom.c
@@ -176,7 +176,7 @@ uint32 cardEepromGetSize() {
 
 		if (id == 0xffffff) {
 			int sr = cardEepromCommand(SPI_EEPROM_RDSR);
-			if (sr == 2) { // Pokémon Mystery Dungeon - Explorers of Sky
+			if (sr == 2) {
 				return 128*1024; // 1Mbit (128KByte)
 			}
 		}


### PR DESCRIPTION
I see you already merged 9cb70adbe72222db8afc25bfc2ac5e24c2f4c8c0, but not this yet so figured I'd open a PR so I could add some notes

Original GodMode9i PRs:
- Line 82: DS-Homebrew/GodMode9i#88 -- fixes dumping 128 KiB EEPROMs (specifically Pokémon Mystery Dungeon: Explorers of Sky)
- Lines 100-181: DS-Homebrew/GodMode9i#79 -- fixes incorrect size detection when the first word was `00000000` because it inverted the number and treated `FFFFFFFF` as a stop condition iirc
   - Improved in: DS-Homebrew/GodMode9i#94 -- improves on the previous fix by checking two separate values, to remove the chance of a save ever coincidentally perfectly matching our check value