### PR TITLE
More EEPROM improvements

### DIFF
--- a/source/common/cardEeprom.c
+++ b/source/common/cardEeprom.c
@@ -121,7 +121,7 @@ uint32 cardEepromGetSize() {
 				// False match, write "TEST" back and keep going
 				cardWriteEeprom(0,(u8*)&buf3,4,type);
 			}
-			size += 8192;
+			size <<= 1;
 		}
 
 		// Restore the first word

--- a/source/common/cardEeprom.c
+++ b/source/common/cardEeprom.c
@@ -106,7 +106,7 @@ uint32 cardEepromGetSize() {
 
 		// Loop until the EEPROM mirrors and the first word shows up again
 		int size = 8192;
-		while (1) {
+		while (size <= 0x800000) {
 			cardReadEeprom(size,(u8*)&buf2,4,type);
 			// Check if it matches, if so check again with another value to ensure no false positives
 			if (buf2 == buf3) {


### PR DESCRIPTION
Per @asiekierka's comments after #9 was merged, I've added a size limit of 8 MB (the largest DS EEPROM save, Art Academy) and changed it to only check powers of two. Per [melonDS's save DB](https://github.com/melonDS-emu/melonDS/blob/master/src/ROMList.h) non-power of 2 EEPROMs do not exist.

I've tested a handful of games using GM9i and it appears to work as before.