### PR TITLE
fatfs: Implement re-entrancy protection.

### DIFF
--- a/include/nds/cothread.h
+++ b/include/nds/cothread.h
@@ -100,6 +100,13 @@ void cothread_yield_irq_aux(uint32_t flags);
 // Returns ID of the thread that is running currently.
 cothread_t cothread_get_current(void);
 
+// Initialize a mutex.
+static inline bool comutex_init(comutex_t *mutex)
+{
+    *mutex = 0;
+    return true;
+}
+
 // Try to acquire a mutex. If the mutex is available, it is acquired and the
 // function returns true. If the mutex can't be acquired, it returns false.
 bool comutex_try_acquire(comutex_t *mutex);

--- a/source/arm9/libc/fatfs/ff.c
+++ b/source/arm9/libc/fatfs/ff.c
@@ -468,10 +468,11 @@ static WORD Fsid;					/* Filesystem mount ID */
 static BYTE CurrVol;				/* Current drive set by f_chdrive() */
 #endif
 
-#if FF_FS_LOCK != 0
+#if FF_FS_LOCK
 static FILESEM Files[FF_FS_LOCK];	/* Open object lock semaphores */
 #if FF_FS_REENTRANT
-static BYTE SysLock;				/* System lock flag (0:no mutex, 1:unlocked, 2:locked) */
+static volatile BYTE SysLock;		/* System lock flag to protect Files[] (0:no mutex, 1:unlocked, 2:locked) */
+static volatile BYTE SysLockVolume;	/* Volume id who is locking Files[] */
 #endif
 #endif
 
@@ -905,6 +906,7 @@ static int lock_volume (	/* 1:Ok, 0:timeout */
 	if (rv && syslock) {			/* System lock reqiered? */
 		rv = ff_mutex_take(FF_VOLUMES);	/* Lock the system */
 		if (rv) {
+			SysLockVolume = fs->ldrv;
 			SysLock = 2;				/* System lock succeeded */
 		} else {
 			ff_mutex_give(fs->ldrv);	/* Failed system lock */
@@ -924,7 +926,7 @@ static void unlock_volume (
 {
 	if (fs && res != FR_NOT_ENABLED && res != FR_INVALID_DRIVE && res != FR_TIMEOUT) {
 #if FF_FS_LOCK
-		if (SysLock == 2) {	/* Is the system locked? */
+		if (SysLock == 2 && SysLockVolume == fs->ldrv) {	/* Is the system locked? */
 			SysLock = 1;
 			ff_mutex_give(FF_VOLUMES);
 		}

--- a/source/arm9/libc/fatfs/ffconf.h
+++ b/source/arm9/libc/fatfs/ffconf.h
@@ -279,7 +279,7 @@
 */
 
 
-#define FF_FS_LOCK		0
+#define FF_FS_LOCK 	0
 /* The option FF_FS_LOCK switches file lock function to control duplicated file open
 /  and illegal operation to open objects. This option must be 0 when FF_FS_READONLY
 /  is 1.
@@ -291,7 +291,7 @@
 /      lock control is independent of re-entrancy. */
 
 
-#define FF_FS_REENTRANT	0
+#define FF_FS_REENTRANT	1
 #define FF_FS_TIMEOUT	1000
 /* The option FF_FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different

--- a/source/arm9/libc/fatfs/ffsystem.c
+++ b/source/arm9/libc/fatfs/ffsystem.c
@@ -18,6 +18,7 @@
 /
 /----------------------------------------------------------------------------*/
 
+#include <nds.h>
 #include "ff.h"
 
 
@@ -54,35 +55,7 @@ void ff_memfree (
 /*------------------------------------------------------------------------*/
 /* Definitions of Mutex                                                   */
 /*------------------------------------------------------------------------*/
-
-#define OS_TYPE	0	/* 0:Win32, 1:uITRON4.0, 2:uC/OS-II, 3:FreeRTOS, 4:CMSIS-RTOS */
-
-
-#if   OS_TYPE == 0	/* Win32 */
-#include <windows.h>
-static HANDLE Mutex[FF_VOLUMES + 1];	/* Table of mutex handle */
-
-#elif OS_TYPE == 1	/* uITRON */
-#include "itron.h"
-#include "kernel.h"
-static mtxid Mutex[FF_VOLUMES + 1];		/* Table of mutex ID */
-
-#elif OS_TYPE == 2	/* uc/OS-II */
-#include "includes.h"
-static OS_EVENT *Mutex[FF_VOLUMES + 1];	/* Table of mutex pinter */
-
-#elif OS_TYPE == 3	/* FreeRTOS */
-#include "FreeRTOS.h"
-#include "semphr.h"
-static SemaphoreHandle_t Mutex[FF_VOLUMES + 1];	/* Table of mutex handle */
-
-#elif OS_TYPE == 4	/* CMSIS-RTOS */
-#include "cmsis_os.h"
-static osMutexId Mutex[FF_VOLUMES + 1];	/* Table of mutex ID */
-
-#endif
-
-
+static comutex_t Mutex[FF_VOLUMES + 1];
 
 /*------------------------------------------------------------------------*/
 /* Create a Mutex                                                         */
@@ -96,33 +69,7 @@ int ff_mutex_create (	/* Returns 1:Function succeeded or 0:Could not create the 
 	int vol				/* Mutex ID: Volume mutex (0 to FF_VOLUMES - 1) or system mutex (FF_VOLUMES) */
 )
 {
-#if OS_TYPE == 0	/* Win32 */
-	Mutex[vol] = CreateMutex(NULL, FALSE, NULL);
-	return (int)(Mutex[vol] != INVALID_HANDLE_VALUE);
-
-#elif OS_TYPE == 1	/* uITRON */
-	T_CMTX cmtx = {TA_TPRI,1};
-
-	Mutex[vol] = acre_mtx(&cmtx);
-	return (int)(Mutex[vol] > 0);
-
-#elif OS_TYPE == 2	/* uC/OS-II */
-	OS_ERR err;
-
-	Mutex[vol] = OSMutexCreate(0, &err);
-	return (int)(err == OS_NO_ERR);
-
-#elif OS_TYPE == 3	/* FreeRTOS */
-	Mutex[vol] = xSemaphoreCreateMutex();
-	return (int)(Mutex[vol] != NULL);
-
-#elif OS_TYPE == 4	/* CMSIS-RTOS */
-	osMutexDef(cmsis_os_mutex);
-
-	Mutex[vol] = osMutexCreate(osMutex(cmsis_os_mutex));
-	return (int)(Mutex[vol] != NULL);
-
-#endif
+	return comutex_init(&Mutex[vol]);
 }
 
 
@@ -137,24 +84,7 @@ void ff_mutex_delete (	/* Returns 1:Function succeeded or 0:Could not delete due
 	int vol				/* Mutex ID: Volume mutex (0 to FF_VOLUMES - 1) or system mutex (FF_VOLUMES) */
 )
 {
-#if OS_TYPE == 0	/* Win32 */
-	CloseHandle(Mutex[vol]);
 
-#elif OS_TYPE == 1	/* uITRON */
-	del_mtx(Mutex[vol]);
-
-#elif OS_TYPE == 2	/* uC/OS-II */
-	OS_ERR err;
-
-	OSMutexDel(Mutex[vol], OS_DEL_ALWAYS, &err);
-
-#elif OS_TYPE == 3	/* FreeRTOS */
-	vSemaphoreDelete(Mutex[vol]);
-
-#elif OS_TYPE == 4	/* CMSIS-RTOS */
-	osMutexDelete(Mutex[vol]);
-
-#endif
 }
 
 
@@ -169,25 +99,8 @@ int ff_mutex_take (	/* Returns 1:Succeeded or 0:Timeout */
 	int vol			/* Mutex ID: Volume mutex (0 to FF_VOLUMES - 1) or system mutex (FF_VOLUMES) */
 )
 {
-#if OS_TYPE == 0	/* Win32 */
-	return (int)(WaitForSingleObject(Mutex[vol], FF_FS_TIMEOUT) == WAIT_OBJECT_0);
-
-#elif OS_TYPE == 1	/* uITRON */
-	return (int)(tloc_mtx(Mutex[vol], FF_FS_TIMEOUT) == E_OK);
-
-#elif OS_TYPE == 2	/* uC/OS-II */
-	OS_ERR err;
-
-	OSMutexPend(Mutex[vol], FF_FS_TIMEOUT, &err));
-	return (int)(err == OS_NO_ERR);
-
-#elif OS_TYPE == 3	/* FreeRTOS */
-	return (int)(xSemaphoreTake(Mutex[vol], FF_FS_TIMEOUT) == pdTRUE);
-
-#elif OS_TYPE == 4	/* CMSIS-RTOS */
-	return (int)(osMutexWait(Mutex[vol], FF_FS_TIMEOUT) == osOK);
-
-#endif
+	// TODO: Implement timeout.
+	return comutex_try_acquire(&Mutex[vol]);
 }
 
 
@@ -202,22 +115,7 @@ void ff_mutex_give (
 	int vol			/* Mutex ID: Volume mutex (0 to FF_VOLUMES - 1) or system mutex (FF_VOLUMES) */
 )
 {
-#if OS_TYPE == 0	/* Win32 */
-	ReleaseMutex(Mutex[vol]);
-
-#elif OS_TYPE == 1	/* uITRON */
-	unl_mtx(Mutex[vol]);
-
-#elif OS_TYPE == 2	/* uC/OS-II */
-	OSMutexPost(Mutex[vol]);
-
-#elif OS_TYPE == 3	/* FreeRTOS */
-	xSemaphoreGive(Mutex[vol]);
-
-#elif OS_TYPE == 4	/* CMSIS-RTOS */
-	osMutexRelease(Mutex[vol]);
-
-#endif
+	comutex_release(&Mutex[vol]);
 }
 
 #endif	/* FF_FS_REENTRANT */


### PR DESCRIPTION
This will avoid filesystem corruption if two cothreads try to write to the filesystem at the same time.