### PR TITLE
fifo: Use locks to protect FIFO communications

### DIFF
--- a/include/nds/fifocommon.h
+++ b/include/nds/fifocommon.h
@@ -335,20 +335,21 @@ int fifoGetDatamsg(int channel, int buffersize, u8 * destbuffer);
 	\param channel the channel to check.
 
 */
-//---------------------------------------------------------------------------------
-static inline void fifoWaitValue32(int channel) {
-//---------------------------------------------------------------------------------
 
-	while(!fifoCheckValue32(channel)) {
-#ifdef ARM9
-		cothread_yield_irq(IRQ_FIFO_NOT_EMPTY);
-#else
-		swiIntrWait(1,IRQ_FIFO_NOT_EMPTY);
-#endif
-	}
-
+static inline void fifoWaitValue32(int channel)
+{
+	while (!fifoCheckValue32(channel))
+		swiIntrWait(1, IRQ_FIFO_NOT_EMPTY);
 }
 
+static inline void fifoWaitValueAsync32(int channel)
+{
+	while (!fifoCheckValue32(channel))
+		cothread_yield_irq(IRQ_FIFO_NOT_EMPTY);
+}
+
+void fifoMutexAcquire(int channel);
+void fifoMutexRelease(int channel);
 
 #ifdef __cplusplus
 };

--- a/source/arm9/sound.c
+++ b/source/arm9/sound.c
@@ -47,12 +47,17 @@ int soundPlayPSG(DutyCycle cycle, u16 freq, u8 volume, u8 pan){
 	msg.SoundPsg.volume = volume;
 	msg.SoundPsg.pan = pan;
 
+	fifoMutexAcquire(FIFO_SOUND);
+
 	fifoSendDatamsg(FIFO_SOUND, sizeof(msg), (u8*)&msg);
+	fifoWaitValueAsync32(FIFO_SOUND);
+	int result = fifoGetValue32(FIFO_SOUND);
 
-	while(!fifoCheckValue32(FIFO_SOUND));
+	fifoMutexRelease(FIFO_SOUND);
 
-	return (int)fifoGetValue32(FIFO_SOUND);
+	return result;
 }
+
 int soundPlayNoise(u16 freq, u8 volume, u8 pan){
 	FifoMessage msg;
 
@@ -61,11 +66,15 @@ int soundPlayNoise(u16 freq, u8 volume, u8 pan){
 	msg.SoundPsg.volume = volume;
 	msg.SoundPsg.pan = pan;
 
+	fifoMutexAcquire(FIFO_SOUND);
+
 	fifoSendDatamsg(FIFO_SOUND, sizeof(msg), (u8*)&msg);
+	fifoWaitValueAsync32(FIFO_SOUND);
+	int result = fifoGetValue32(FIFO_SOUND);
 
-	while(!fifoCheckValue32(FIFO_SOUND));
+	fifoMutexRelease(FIFO_SOUND);
 
-	return (int)fifoGetValue32(FIFO_SOUND);
+	return result;
 }
 
 int soundPlaySample(const void* data, SoundFormat format, u32 dataSize, u16 freq, u8 volume, u8 pan, bool loop, u16 loopPoint){ 
@@ -82,11 +91,15 @@ int soundPlaySample(const void* data, SoundFormat format, u32 dataSize, u16 freq
 	msg.SoundPlay.loopPoint = loopPoint;
 	msg.SoundPlay.dataSize = dataSize >> 2;
 
+	fifoMutexAcquire(FIFO_SOUND);
+
 	fifoSendDatamsg(FIFO_SOUND, sizeof(msg), (u8*)&msg);
+	fifoWaitValueAsync32(FIFO_SOUND);
+	int result = fifoGetValue32(FIFO_SOUND);
 
-	while(!fifoCheckValue32(FIFO_SOUND));
+	fifoMutexRelease(FIFO_SOUND);
 
-	return (int)fifoGetValue32(FIFO_SOUND);
+	return result;
 }
 
 void soundPause(int soundId){
@@ -144,12 +157,17 @@ int soundMicRecord(void *buffer, u32 bufferLength, MicFormat format, int freq, M
 
 	fifoSetDatamsgHandler(FIFO_SOUND, micBufferHandler, 0);
 
+	fifoMutexAcquire(FIFO_SOUND);
+
 	fifoSendDatamsg(FIFO_SOUND, sizeof(msg), (u8*)&msg);
+	fifoWaitValueAsync32(FIFO_SOUND);
+	int result = fifoGetValue32(FIFO_SOUND);
 
-	while(!fifoCheckValue32(FIFO_SOUND));
+	fifoMutexRelease(FIFO_SOUND);
 
-	return (int)fifoGetValue32(FIFO_SOUND);
+	return result;
 }
+
 void soundMicOff(void){
 	fifoSendValue32(FIFO_SOUND, MIC_STOP);
 }

--- a/source/arm9/storage/card.c
+++ b/source/arm9/storage/card.c
@@ -18,14 +18,19 @@ bool cardReadArm7(void *dest, size_t offset, size_t size)
 	msg.sdParams.numsectors = size;
 	msg.sdParams.buffer = dest;
 
+	fifoMutexAcquire(FIFO_STORAGE);
+
 	// Let the ARM7 access the slot-1
 	sysSetCardOwner(BUS_OWNER_ARM7);
 
 	fifoSendDatamsg(FIFO_STORAGE, sizeof(msg), (u8 *)&msg);
 
-	fifoWaitValue32(FIFO_STORAGE);
+	fifoWaitValueAsync32(FIFO_STORAGE);
 	DC_InvalidateRange(dest, size);
 
 	int result = fifoGetValue32(FIFO_STORAGE);
+
+	fifoMutexRelease(FIFO_STORAGE);
+
 	return result != 0;
 }

--- a/source/arm9/storage/dldi.c
+++ b/source/arm9/storage/dldi.c
@@ -60,21 +60,27 @@ bool dldi_arm7_startup(void)
 	msg.type = DLDI_STARTUP;
 	msg.sdParams.buffer = &_io_dldi_stub.ioInterface;
 
+	fifoMutexAcquire(FIFO_STORAGE);
+
 	fifoSendDatamsg(FIFO_STORAGE, sizeof(msg), (u8 *)&msg);
-
-	fifoWaitValue32(FIFO_STORAGE);
-
+	fifoWaitValueAsync32(FIFO_STORAGE);
 	int result = fifoGetValue32(FIFO_STORAGE);
+
+	fifoMutexRelease(FIFO_STORAGE);
+
 	return result != 0;
 }
 
 bool dldi_arm7_is_inserted(void)
 {
+	fifoMutexAcquire(FIFO_STORAGE);
+
 	fifoSendValue32(FIFO_STORAGE, DLDI_IS_INSERTED);
-
-	fifoWaitValue32(FIFO_STORAGE);
-
+	fifoWaitValueAsync32(FIFO_STORAGE);
 	int result = fifoGetValue32(FIFO_STORAGE);
+
+	fifoMutexRelease(FIFO_STORAGE);
+
 	return result != 0;
 }
 
@@ -88,12 +94,16 @@ bool dldi_arm7_read_sectors(sec_t sector, sec_t numSectors, void *buffer)
 	msg.sdParams.numsectors = numSectors;
 	msg.sdParams.buffer = buffer;
 
+	fifoMutexAcquire(FIFO_STORAGE);
+
 	fifoSendDatamsg(FIFO_STORAGE, sizeof(msg), (u8 *)&msg);
 
-	fifoWaitValue32(FIFO_STORAGE);
+	fifoWaitValueAsync32(FIFO_STORAGE);
 	DC_InvalidateRange(buffer, numSectors * 512);
 
 	int result = fifoGetValue32(FIFO_STORAGE);
+
+	fifoMutexRelease(FIFO_STORAGE);
 
 	return result != 0;
 }
@@ -108,33 +118,43 @@ bool dldi_arm7_write_sectors(sec_t sector, sec_t numSectors, const void *buffer)
 	msg.sdParams.numsectors = numSectors;
 	msg.sdParams.buffer = (void *)buffer;
 
+	fifoMutexAcquire(FIFO_STORAGE);
+
 	fifoSendDatamsg(FIFO_STORAGE, sizeof(msg), (u8 *)&msg);
 
-	fifoWaitValue32(FIFO_STORAGE);
+	fifoWaitValueAsync32(FIFO_STORAGE);
 	DC_InvalidateRange(buffer, numSectors * 512);
 
 	int result = fifoGetValue32(FIFO_STORAGE);
+
+	fifoMutexRelease(FIFO_STORAGE);
 
 	return result != 0;
 }
 
 bool dldi_arm7_clear_status(void)
 {
+	fifoMutexAcquire(FIFO_STORAGE);
+
 	fifoSendValue32(FIFO_STORAGE, DLDI_CLEAR_STATUS);
-
-	fifoWaitValue32(FIFO_STORAGE);
-
+	fifoWaitValueAsync32(FIFO_STORAGE);
 	int result = fifoGetValue32(FIFO_STORAGE);
+
+	fifoMutexRelease(FIFO_STORAGE);
+
 	return result != 0;
 }
 
 bool dldi_arm7_shutdown(void)
 {
+	fifoMutexAcquire(FIFO_STORAGE);
+
 	fifoSendValue32(FIFO_STORAGE, DLDI_SHUTDOWN);
-
-	fifoWaitValue32(FIFO_STORAGE);
-
+	fifoWaitValueAsync32(FIFO_STORAGE);
 	int result = fifoGetValue32(FIFO_STORAGE);
+
+	fifoMutexRelease(FIFO_STORAGE);
+
 	return result != 0;
 }
 

--- a/source/common/fifosystem.c
+++ b/source/common/fifosystem.c
@@ -1,7 +1,8 @@
-#include <nds/fifocommon.h>
-#include <nds/ipc.h>
-#include <nds/interrupts.h>
 #include <nds/bios.h>
+#include <nds/cothread.h>
+#include <nds/fifocommon.h>
+#include <nds/interrupts.h>
+#include <nds/ipc.h>
 #include <nds/system.h>
 
 #include <string.h>
@@ -161,6 +162,8 @@ fifo_queue	fifo_value32_queue[FIFO_NUM_CHANNELS];
 fifo_queue fifo_buffer_free = {0,FIFO_BUFFER_ENTRIES-1};
 fifo_queue fifo_send_queue = { FIFO_BUFFER_TERMINATE, FIFO_BUFFER_TERMINATE};
 fifo_queue fifo_receive_queue = { FIFO_BUFFER_TERMINATE, FIFO_BUFFER_TERMINATE};
+
+static comutex_t fifo_mutex[FIFO_NUM_CHANNELS];
 
 vu32	fifo_freewords = FIFO_BUFFER_ENTRIES;
 
@@ -640,4 +643,16 @@ bool fifoInit() {
 	irqEnable(IRQ_FIFO_NOT_EMPTY|IRQ_FIFO_EMPTY);
 
 	return true;
+}
+
+static comutex_t fifo_mutex[FIFO_NUM_CHANNELS];
+
+void fifoMutexAcquire(int channel)
+{
+    comutex_acquire(&fifo_mutex[channel]);
+}
+
+void fifoMutexRelease(int channel)
+{
+    comutex_release(&fifo_mutex[channel]);
 }


### PR DESCRIPTION
After introducing cothreads, whenever we yield from the ARM9 while waiting for the ARM7 to reply, it is possible that two threads get their responses in the wrong order.

Thread 1 sends message 1, it yields while waiting for the response, thread 2 sends message 2, and response 1 is ready, so it reads it without yielding, and eventually thread 1 sees response 2.

This PR introduces fifoWaitValueAsynch32() so that not all FIFO communications need to be asynchronous, only the communications that explicitly use this function.

It also switches the storage and sound FIFO subsystems to use locks and the new asynchronous wait function.