### PR TITLE
fatfs: Add statvfs() and fstatvfs() support.

### DIFF
--- a/include/sys/statvfs.h
+++ b/include/sys/statvfs.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2023 Adrian Siekierka
+
+#ifndef _SYS_STATVFS_H
+#define _SYS_STATVFS_H
+#if defined( __cplusplus )
+extern "C" {
+#endif
+
+#include <sys/types.h>
+
+struct statvfs {
+	unsigned long f_bsize;
+	unsigned long f_frsize;
+	fsblkcnt_t f_blocks;
+	fsblkcnt_t f_bfree;
+	fsblkcnt_t f_bavail;
+	fsfilcnt_t f_files;
+	fsfilcnt_t f_ffree;
+	fsfilcnt_t f_favail;
+	unsigned long f_fsid;
+	unsigned long f_flag;
+	unsigned long f_namemax;
+};
+
+#define ST_RDONLY 0x1
+#define ST_NOSUID 0x2
+
+int statvfs(const char *restrict path, struct statvfs *restrict buf);
+int fstatvfs(int fd, struct statvfs *buf);
+
+#if defined( __cplusplus )
+} // extern "C"
+#endif
+#endif // define _SYS_STATVFS_H

--- a/source/arm9/libc/fatfs/ff.c
+++ b/source/arm9/libc/fatfs/ff.c
@@ -4835,8 +4835,9 @@ FRESULT f_getfree (
 
 
 	/* Get logical drive */
-	res = mount_volume(&path, &fs, 0);
-	if (res == FR_OK) {
+	/* BlocksDS: Allow specifying FATFS instance directly */
+	if (path == NULL) fs = *fatfs;
+	if (path == NULL || (res = mount_volume(&path, &fs, 0)) == FR_OK) {
 		*fatfs = fs;				/* Return ptr to the fs object */
 		/* If free_clst is valid, return it without full FAT scan */
 		if (fs->free_clst <= fs->n_fatent - 2) {

--- a/source/arm9/libc/filesystem.c
+++ b/source/arm9/libc/filesystem.c
@@ -121,7 +121,7 @@ int open(const char *path, int flags, ...)
 ssize_t read(int fd, void *ptr, size_t len)
 {
     // This isn't handled here
-    if (fd == STDIN_FILENO)
+    if ((fd >= STDIN_FILENO) && (fd <= STDERR_FILENO))
         return -1;
 
     FIL *fp = (FIL *)fd;
@@ -156,6 +156,10 @@ ssize_t write(int fd, const void *ptr, size_t len)
 
 int close(int fd)
 {
+    // This isn't handled here
+    if ((fd >= STDIN_FILENO) && (fd <= STDERR_FILENO))
+        return -1;
+
     FIL *fp = (FIL *)fd;
 
     FRESULT result = f_close(fp);
@@ -171,6 +175,10 @@ int close(int fd)
 
 off_t lseek(int fd, off_t offset, int whence)
 {
+    // This isn't handled here
+    if ((fd >= STDIN_FILENO) && (fd <= STDERR_FILENO))
+        return -1;
+
     FIL *fp = (FIL *)fd;
 
     if (whence == SEEK_END)
@@ -278,6 +286,10 @@ int stat(const char *path, struct stat *st)
 
 int fstat(int fd, struct stat *st)
 {
+    // This isn't handled here
+    if ((fd >= STDIN_FILENO) && (fd <= STDERR_FILENO))
+        return -1;
+
     FIL *fp = (FIL *)fd;
 
     st->st_size = fp->obj.objsize;
@@ -404,6 +416,10 @@ static int ftruncate_internal(int fd, off_t length)
 
 int ftruncate(int fd, off_t length)
 {
+    // This isn't handled here
+    if ((fd >= STDIN_FILENO) && (fd <= STDERR_FILENO))
+        return -1;
+
     FIL *fp = (FIL *)fd;
 
     if ((size_t)length == (size_t)f_size(fp))

--- a/source/arm9/libc/statvfs.c
+++ b/source/arm9/libc/statvfs.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2023 Adrian Siekierka
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "fatfs/ff.h"
+#include "fatfs_internal.h"
+#include <sys/statvfs.h>
+#include <sys/unistd.h>
+
+static void _statvfs_populate(FATFS *fs, DWORD nclst, struct statvfs *buf) {
+#if FF_MAX_SS != FF_MIN_SS
+	buf->f_bsize = fs->csize * fs->ssize;
+#else
+	buf->f_bsize = fs->csize * FF_MAX_SS;
+#endif
+	buf->f_frsize = buf->f_bsize;
+	buf->f_blocks = fs->n_fatent - 2;
+	buf->f_bfree = nclst;
+	buf->f_bavail = nclst;
+	buf->f_files = 0;
+	buf->f_ffree = 0;
+	buf->f_favail = 0;
+	buf->f_fsid = fs->fs_type;
+	buf->f_flag = 0;
+	buf->f_namemax = fs->fs_type >= FS_FAT32 ? 255 : 12;
+}
+
+int statvfs(const char *restrict path, struct statvfs *restrict buf) {
+	FATFS *fs;
+	DWORD nclst = 0;
+	FRESULT result;
+
+	if ((result = f_getfree(path, &nclst, &fs)) != FR_OK || fs == NULL) {
+		errno = EIO;
+		return -1;
+	}
+
+	_statvfs_populate(fs, nclst, buf);
+	return 0;
+}
+
+int fstatvfs(int fd, struct statvfs *buf) {
+	FIL *fp;
+	FATFS *fs;
+	DWORD nclst = 0;
+	FRESULT result;
+
+	// This isn't handled here
+	if ((fd >= STDIN_FILENO) && (fd <= STDERR_FILENO))
+		return -1;
+
+	fp = (FIL*) fd;
+	fs = fp->obj.fs;
+
+	// This is not a standard use of f_getfree - there's a patch
+	// in ff.c which makes this (path == NULL, fs provided) work.
+	if (fs == NULL || (result = f_getfree(NULL, &nclst, &fs)) != FR_OK) {
+		errno = EIO;
+		return -1;
+	}
+
+	_statvfs_populate(fs, nclst, buf);
+	return 0;
+}


### PR DESCRIPTION
Used by NitroTracker.

Also added `int fd` guards to more functions.