### PR TITLE
arm7: add inputSetLidSleepDuration(), fix C++ guards, KEYXY defines cleanup, document arm7/input.h functions

### DIFF
--- a/include/nds/arm7/clock.h
+++ b/include/nds/arm7/clock.h
@@ -18,7 +18,6 @@
 extern "C" {
 #endif
 
-
 #include <nds/arm7/serial.h>
 
 // RTC registers

--- a/include/nds/arm7/i2c.h
+++ b/include/nds/arm7/i2c.h
@@ -11,6 +11,10 @@
 #error i2c header is for ARM7 only
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <nds/ndstypes.h>
 
 #define REG_I2CDATA	(*(vu8 *)0x4004500)
@@ -46,5 +50,9 @@ u8 i2cWriteRegister(u8 device, u8 reg, u8 data);
 u8 i2cReadRegister(u8 device, u8 reg);
 u8 i2cWriteRegister16(u8 device, u16 reg, u16 data);
 u16 i2cReadRegister16(u8 device, u16 reg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // I2C_ARM7_INCLUDE

--- a/include/nds/arm7/input.h
+++ b/include/nds/arm7/input.h
@@ -11,6 +11,22 @@
 extern "C" {
 #endif
 
+#include <nds/ndstypes.h>
+
+/**
+ * @brief Set the amount of frames the lid has to be closed for to trigger sleep.
+ *
+ * Setting this value to 0 will suppress system sleep on lid closing.
+ *
+ * @Param frames The number of frames.
+ */
+void inputSetLidSleepDuration(u16 frames);
+
+/**
+ * @brief Send ARM7-side input information (X, Y, touch, lid) to ARM9 via FIFO.
+ *
+ * This should ideally be called once per frame on the ARM7 CPU.
+ */
 void inputGetAndSend(void);
 
 #ifdef __cplusplus

--- a/include/nds/arm7/sdmmc.h
+++ b/include/nds/arm7/sdmmc.h
@@ -5,12 +5,15 @@
 #ifndef __SDMMC_H__
 #define __SDMMC_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <nds/ndstypes.h>
 
 #define DATA32_SUPPORT
 
 #define SDMMC_BASE	0x04004800
-
 
 #define REG_SDCMD       0x00
 #define REG_SDPORTSEL   0x02
@@ -194,5 +197,9 @@ static inline void setckl(u32 data) {
     sdmmc_mask16(REG_SDCLKCTL, 0x2FF, data & 0x2FF);
     sdmmc_mask16(REG_SDCLKCTL, 0x0, 0x100);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/nds/arm7/serial.h
+++ b/include/nds/arm7/serial.h
@@ -13,15 +13,22 @@
 #error Serial header is for ARM7 only
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <nds/bios.h>
-
 
 // 'Networking'
 #define REG_RCNT	(*(vu16*)0x04000134)
 #define REG_KEYXY	(*(vu16*)0x04000136)
 #define RTC_CR		(*(vu16*)0x04000138)
 #define RTC_CR8		(*( vu8*)0x04000138)
+
+#define KEYXY_X		BIT(0)
+#define KEYXY_Y		BIT(1)
+#define KEYXY_TOUCH	BIT(6)
+#define KEYXY_LID	BIT(7)
 
 #define REG_SIOCNT	(*(vu16*)0x04000128)
 
@@ -69,9 +76,6 @@
 
 // Fixme: does this stuff really belong in serial.h?
 
-
-// Fixme: does this stuff really belong in serial.h?
-
 // Firmware commands
 #define FIRMWARE_WREN 0x06
 #define FIRMWARE_WRDI 0x04
@@ -95,6 +99,9 @@ void SerialWaitBusy(void) {
 // Read the firmware
 void readFirmware(u32 address, void * destination, u32 size);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/include/nds/ndma.h
+++ b/include/nds/ndma.h
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2005 Jason Rogers (dovoto)
 // Copyright (C) 2005 Dave Murphy (WinterMute)
-// Copyright (C) 2023 Adrian Siekierka (asie)
+// Copyright (c) 2023 Adrian "asie" Siekierka
 
 #ifndef NDS_NDMA_INCLUDE
 #define NDS_NDMA_INCLUDE

--- a/include/sys/statvfs.h
+++ b/include/sys/statvfs.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Zlib
 //
-// Copyright (c) 2023 Adrian Siekierka
+// Copyright (c) 2023 Adrian "asie" Siekierka
 
 #ifndef _SYS_STATVFS_H
 #define _SYS_STATVFS_H

--- a/source/arm7/camera.twl.c
+++ b/source/arm7/camera.twl.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Zlib
 //
-// Copyright (C) 2023 Adrian "asie" Siekierka
+// Copyright (c) 2023 Adrian "asie" Siekierka
 
 // Camera control for the ARM7
 

--- a/source/arm7/touch.c
+++ b/source/arm7/touch.c
@@ -41,7 +41,7 @@ static u8 CheckStylus(void)
 	SerialWaitBusy();
 
 	if(last_time_touched == 1){
-		if( !(REG_KEYXY & 0x40) )
+		if( !(REG_KEYXY & KEYXY_TOUCH) )
 			return 1;
 		else{
 			REG_SPICNT = SPI_ENABLE | SPI_BAUD_2MHz | SPI_DEVICE_TOUCH | SPI_CONTINUOUS;
@@ -58,10 +58,10 @@ static u8 CheckStylus(void)
 
 			SerialWaitBusy();
 
-			return !(REG_KEYXY & 0x40) ? 2 : 0;
+			return !(REG_KEYXY & KEYXY_TOUCH) ? 2 : 0;
 		}
 	}else{
-		return !(REG_KEYXY & 0x40) ? 1 : 0;
+		return !(REG_KEYXY & KEYXY_TOUCH) ? 1 : 0;
 	}
 }
 
@@ -327,7 +327,7 @@ bool touchPenDown(void)
 	if (cdcIsAvailable()) {
 		down = cdcTouchPenDown();
 	} else {
-		down = !(REG_KEYXY & (1<<6));
+		down = !(REG_KEYXY & KEYXY_TOUCH);
 	}
 	leaveCriticalSection(oldIME);
 	return down;

--- a/source/arm9/libc/statvfs.c
+++ b/source/arm9/libc/statvfs.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Zlib
 //
-// Copyright (c) 2023 Adrian Siekierka
+// Copyright (c) 2023 Adrian "asie" Siekierka
 
 #include <errno.h>
 #include <stdio.h>

--- a/source/arm9/peripherals/camera.twl.c
+++ b/source/arm9/peripherals/camera.twl.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Zlib
 //
-// Copyright (C) 2023 Adrian "asie" Siekierka
+// Copyright (c) 2023 Adrian "asie" Siekierka
 
 // Camera control for the ARM9
 


### PR DESCRIPTION
This allows adding a way to use `inputGetAndSend()` while suppressing lid sleep for advanced users (f.e. during critical operations), without having to copy-paste a bunch of code.
