### PR TITLE
image, pcx, fatfs: minor fixes

### DIFF
--- a/include/nds/arm9/image.h
+++ b/include/nds/arm9/image.h
@@ -52,12 +52,14 @@ extern "C" {
 /// Destructively converts a 24-bit image to 16-bit
 ///
 /// @param img Pointer to the image to manipulate.
-void image24to16(sImage *img);
+/// @return true on success, false on failure.
+bool image24to16(sImage *img);
 
 /// Destructively converts an 8-bit image to 16 bit setting the alpha bit.
 ///
 /// @param img Pointer to the image to manipulate.
-void image8to16(sImage *img);
+/// @return true on success, false on failure.
+bool image8to16(sImage *img);
 
 /// Destructively converts an 8-bit image to 16-bit with alpha bit cleared for
 /// the supplied palette index.
@@ -65,7 +67,8 @@ void image8to16(sImage *img);
 /// @param img Pointer to the image to manipulate.
 /// @param transparentColor Color indexes equal to this value will have the
 ///                         alpha bit clear
-void image8to16trans(sImage *img, u8 transparentColor);
+/// @return true on success, false on failure.
+bool image8to16trans(sImage *img, u8 transparentColor);
 
 /// Frees the image data.
 ///
@@ -77,7 +80,8 @@ void imageDestroy(sImage *img);
 /// Tiles 8-bit image data into a sequence of 8x8 tiles.
 ///
 /// @param img Pointer to the image to manipulate.
-void imageTileData(sImage *img);
+/// @return true on success, false on failure.
+bool imageTileData(sImage *img);
 
 #ifdef __cplusplus
 }

--- a/include/nds/arm9/pcx.h
+++ b/include/nds/arm9/pcx.h
@@ -37,8 +37,8 @@ extern "C" {
 /// @param pcx A pointer to the pcx file loaded into memory.
 /// @param image The image structure to fill in (the loader will allocate room
 ///              for the palette and pixel data)
-/// @return 1 on success, 0 on failure.
-int loadPCX(const unsigned char *pcx, sImage *image);
+/// @return true on success, false on failure.
+bool loadPCX(const unsigned char *pcx, sImage *image);
 
 #ifdef __cplusplus
 }

--- a/source/arm9/image.c
+++ b/source/arm9/image.c
@@ -12,11 +12,11 @@
 #include <nds/dma.h>
 #include <nds/ndstypes.h>
 
-void image24to16(sImage *img)
+bool image24to16(sImage *img)
 {
     u16 *temp = malloc(img->height * img->width * 2);
     if (temp == NULL)
-        return;
+        return false;
 
     for (int y = 0; y < img->height; y++)
     {
@@ -34,16 +34,18 @@ void image24to16(sImage *img)
 
     img->bpp = 16;
     img->image.data16 = temp;
+
+    return true;
 }
 
-void image8to16(sImage *img)
+bool image8to16(sImage *img)
 {
     sassert(img->bpp == 8, "image must be 8 bpp");
     sassert(img->palette != NULL, "image must have a palette set");
 
     u16 *temp = malloc(img->height * img->width * 2);
     if (temp == NULL)
-        return;
+        return false;
 
     for (int i = 0; i < img->height * img->width; i++)
         temp[i] = img->palette[img->image.data8[i]] | (1 << 15);
@@ -55,16 +57,18 @@ void image8to16(sImage *img)
 
     img->bpp = 16;
     img->image.data16 = temp;
+
+    return true;
 }
 
-void image8to16trans(sImage *img, u8 transparentColor)
+bool image8to16trans(sImage *img, u8 transparentColor)
 {
     sassert(img->bpp == 8, "image must be 8 bpp");
     sassert(img->palette != NULL, "image must have a palette set");
 
     u16 *temp = malloc(img->height * img->width * 2);
     if (temp == NULL)
-        return;
+        return false;
 
     for (int i = 0; i < img->height * img->width; i++)
     {
@@ -83,13 +87,15 @@ void image8to16trans(sImage *img, u8 transparentColor)
 
     img->bpp = 16;
     img->image.data16 = temp;
+
+    return true;
 }
 
-void imageTileData(sImage *img)
+bool imageTileData(sImage *img)
 {
     // Can only tile 8 bit data that is a multiple of 8 in dimention
-    if (img->bpp != 8 || (img->height & 3) != 0 || (img->width & 3) != 0)
-        return;
+    sassert(img->bpp == 8, "image must be 8 bpp");
+    sassert((img->height & 7) == 0 && (img->width & 7) == 0, "image must be a multiple of 8 in dimension");
 
     int th = img->height >> 3;
     int tw = img->width >> 3;
@@ -97,7 +103,7 @@ void imageTileData(sImage *img)
     // Buffer to hold data
     u32 *temp = malloc(img->height * img->width);
     if (temp == NULL)
-        return;
+        return false;
 
     int i = 0;
 
@@ -116,6 +122,8 @@ void imageTileData(sImage *img)
     free(img->image.data32);
 
     img->image.data32 = (u32 *)temp;
+
+    return true;
 }
 
 void imageDestroy(sImage *img)

--- a/source/arm9/libc/fatfs.c
+++ b/source/arm9/libc/fatfs.c
@@ -193,14 +193,14 @@ char *fatGetDefaultCwd(void)
         if (argv0)
         {
             if (strncmp(argv0, fat_drive, strlen(fat_drive)) == 0)
-                return strdup("fat:/");
+                return strdup(fat_drive);
         }
 
-        return strdup("sd:/");
+        return strdup(sd_drive);
     }
     else
     {
-        return strdup("fat:/");
+        return strdup(fat_drive);
     }
 }
 
@@ -260,7 +260,7 @@ bool fatInit(uint32_t cache_size_pages, bool set_as_default_device)
         bool require_sd = true;
         default_drive = sd_drive;
 
-        if (strncmp(default_cwd, fat_drive, strlen(fat_drive)) == 0)
+        if (default_cwd != NULL && strncmp(default_cwd, fat_drive, strlen(fat_drive)) == 0)
         {
             // This is the unusual case of the ROM being loaded from the
             // DLDI device instead of the internal SD card.
@@ -314,6 +314,7 @@ bool fatInit(uint32_t cache_size_pages, bool set_as_default_device)
         }
     }
 
+    free(default_cwd);
     fat_initialized = true;
     return true;
 

--- a/source/arm9/libc/fatfs/ffconf.h
+++ b/source/arm9/libc/fatfs/ffconf.h
@@ -307,6 +307,8 @@
 /  The FF_FS_TIMEOUT defines timeout period in unit of O/S time tick.
 */
 
-
+#include <stdlib.h>
+#define ff_memalloc malloc
+#define ff_memfree free
 
 /*--- End of configuration options ---*/

--- a/source/arm9/libc/fatfs/ffsystem.c
+++ b/source/arm9/libc/fatfs/ffsystem.c
@@ -22,35 +22,6 @@
 #include "ff.h"
 
 
-#if FF_USE_LFN == 3	/* Use dynamic memory allocation */
-
-/*------------------------------------------------------------------------*/
-/* Allocate/Free a Memory Block                                           */
-/*------------------------------------------------------------------------*/
-
-#include <stdlib.h>		/* with POSIX API */
-
-
-void* ff_memalloc (	/* Returns pointer to the allocated memory block (null if not enough core) */
-	UINT msize		/* Number of bytes to allocate */
-)
-{
-	return malloc((size_t)msize);	/* Allocate a new memory block */
-}
-
-
-void ff_memfree (
-	void* mblock	/* Pointer to the memory block to free (no effect if null) */
-)
-{
-	free(mblock);	/* Free the memory block */
-}
-
-#endif
-
-
-
-
 #if FF_FS_REENTRANT	/* Mutal exclusion */
 /*------------------------------------------------------------------------*/
 /* Definitions of Mutex                                                   */

--- a/source/arm9/pcx.c
+++ b/source/arm9/pcx.c
@@ -9,7 +9,7 @@
 #include <nds/arm9/pcx.h>
 #include <nds/arm9/video.h>
 
-int loadPCX(const unsigned char *pcx, sImage *image)
+bool loadPCX(const unsigned char *pcx, sImage *image)
 {
     // struct rgb {
     //     unsigned char b,g,r;
@@ -29,10 +29,18 @@ int loadPCX(const unsigned char *pcx, sImage *image)
     int size = image->width * image->height;
 
     if (hdr->bitsPerPixel != 8)
-        return 0;
+        return false;
 
     unsigned char *scanline = image->image.data8 = malloc(size);
+    if (scanline == NULL)
+        return false;
+
     image->palette = malloc(256 * 2);
+    if (image->palette == NULL)
+    {
+        free(scanline);
+        return false;
+    }
 
     int count = 0;
 
@@ -68,7 +76,7 @@ int loadPCX(const unsigned char *pcx, sImage *image)
         image->image.data8 = 0;
         free(image->palette);
         image->palette = 0;
-        return 0;
+        return false;
     }
 
     pcx++;
@@ -85,5 +93,5 @@ int loadPCX(const unsigned char *pcx, sImage *image)
         image->palette[i] = RGB15(r >> 3, g >> 3, b >> 3);
     }
 
-    return 1;
+    return true;
 }


### PR DESCRIPTION
* image, pcx: fix missing checks, use bools, unify error checking approach - I spotted this one by looking at the commit history; just a minor improvement.
* fatfs: inline ff_memalloc/ff_memfree - they're just wrappers to malloc/free, so why not?
* fatfs: fix memory leak in fatInit() - these two issues have been spotted by using GCC 12's `-fanalyzer` static analyzer.