### PR TITLE
dldi_asm: define DLDI_SIZE_2KB

### DIFF
--- a/include/nds/arm9/dldi_asm.h
+++ b/include/nds/arm9/dldi_asm.h
@@ -20,6 +20,7 @@
 #define DLDI_SIZE_16KB  0x0e
 #define DLDI_SIZE_8KB   0x0d
 #define DLDI_SIZE_4KB   0x0c
+#define DLDI_SIZE_2KB   0x0b
 #define DLDI_SIZE_1KB   0x0a
 
 #endif // LIBNDS_ARM9_DLDI_ASM_H__


### PR DESCRIPTION
The DLDI interface says:
- Log [base-2] of the size of this driver in bytes.

log2(2048) == 0xB.

This was used in other DLDI files in the past, but to use this header meant that one had to resort to using DLDI_SIZE_4KB instead due to this define missing.