### PR TITLE
teak: Add libteak and ARM9 teak support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ endif
 # Targets
 # -------
 
-.PHONY: all arm7 arm9 clean docs install
+.PHONY: all arm7 arm9 teak clean docs install
 
-all: $(VERSION_HEADER) arm9 arm7
+all: $(VERSION_HEADER) arm9 arm7 teak
 
 $(VERSION_HEADER): Makefile
 	@echo "#ifndef LIBNDS_NDS_LIBVERSION_H__" > $@
@@ -54,6 +54,10 @@ arm9:
 arm7:
 	@+$(MAKE) -f Makefile.arm7 --no-print-directory
 	@+$(MAKE) -f Makefile.arm7 --no-print-directory DEBUG=1
+
+teak:
+	@+$(MAKE) -f Makefile.teak --no-print-directory
+	@+$(MAKE) -f Makefile.teak --no-print-directory DEBUG=1
 
 clean:
 	@echo "  CLEAN"

--- a/Makefile.teak
+++ b/Makefile.teak
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+BLOCKSDS	?= /opt/blocksds/core
+BLOCKSDSEXT	?= /opt/blocksds/external
+
+# Source code paths
+# -----------------
+
+SOURCEDIRS	:= source/teak
+INCLUDEDIRS	:= include
+BINDIRS		:=
+
+# Defines passed to all files
+# ---------------------------
+
+DEFINES		:=
+
+# Libraries
+# ---------
+
+LIBDIRS		:=
+
+# Build artifacts
+# ---------------
+
+ifeq ($(DEBUG),1)
+NAME		:= libteakd
+BUILDDIR	:= build/debug/teak
+else
+NAME		:= libteak
+BUILDDIR	:= build/release/teak
+endif
+
+ARCHIVE		:= lib/$(NAME).a
+
+# Tools
+# -----
+
+LLVM_TEAK := /opt/wonderful/toolchain/llvm-teak/bin/
+
+CC		:= $(LLVM_TEAK)clang
+CXX		:= $(LLVM_TEAK)clang++
+AR		:= $(LLVM_TEAK)llvm-ar
+MKDIR		:= mkdir
+RM		:= rm -rf
+
+# Verbose flag
+# ------------
+
+ifeq ($(VERBOSE),1)
+V		:=
+else
+V		:= @
+endif
+
+# Source files
+# ------------
+
+ifneq ($(BINDIRS),)
+    SOURCES_BIN	:= $(shell find -L $(BINDIRS) -name "*.bin")
+    INCLUDEDIRS	+= $(addprefix $(BUILDDIR)/,$(BINDIRS))
+endif
+
+SOURCES_S	:= $(shell find -L $(SOURCEDIRS) -name "*.s")
+SOURCES_C	:= $(shell find -L $(SOURCEDIRS) -name "*.c")
+SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
+
+# Compiler and linker flags
+# -------------------------
+
+DEFINES		+= -D__NDS__ -DTEAK
+
+ARCH		:= --target=teak -march=teak
+
+WARNFLAGS	:= -Wall
+
+INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
+		   $(foreach path,$(LIBDIRS),-I$(path)/include)
+
+LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
+
+ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(ARCH) \
+		    $(INCLUDEFLAGS) \
+		    -integrated-as -nostdlib -ffreestanding -fno-builtin
+
+CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(ARCH) \
+		    $(INCLUDEFLAGS) -O2 \
+		    -integrated-as -nostdlib -ffreestanding -fno-builtin
+
+CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(ARCH) \
+		    $(INCLUDEFLAGS) -O2 \
+		    -integrated-as -nostdlib -ffreestanding -fno-builtin \
+		    -fno-rtti -fno-exceptions
+
+# Intermediate build files
+# ------------------------
+
+OBJS_ASSETS	:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_BIN)))
+
+HEADERS_ASSETS	:= $(patsubst %.bin,%_bin.h,$(addprefix $(BUILDDIR)/,$(SOURCES_BIN)))
+
+OBJS_SOURCES	:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_S))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_C))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_CPP)))
+
+OBJS		:= $(OBJS_ASSETS) $(OBJS_SOURCES)
+
+DEPS		:= $(OBJS:.o=.d)
+
+# Targets
+# -------
+
+.PHONY: all clean
+
+all: $(ARCHIVE)
+
+$(ARCHIVE): $(OBJS)
+	@echo "  AR.TEAK $@"
+	@$(MKDIR) -p $(@D)
+	$(V)$(AR) rcs $@ $(OBJS)
+
+clean:
+	@echo "  CLEAN.TEAK"
+	$(V)$(RM) $(ARCHIVE) $(BUILDDIR)
+
+# Rules
+# -----
+
+$(BUILDDIR)/%.s.o : %.s
+	@echo "  AS.TEAK $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(ASFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.c.o : %.c
+	@echo "  CC.TEAK $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.cpp.o : %.cpp
+	@echo "  CXX.TEAK $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CXX) $(CXXFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.bin.o $(BUILDDIR)/%_bin.h : %.bin
+	@echo "  BIN2C.TEAK $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(BLOCKSDS)/tools/bin2c/bin2c $< $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $(BUILDDIR)/$*.bin.o $(BUILDDIR)/$*_bin.c
+
+# All assets must be built before the source code
+# -----------------------------------------------
+
+$(SOURCES_S) $(SOURCES_C) $(SOURCES_CPP): $(HEADERS_ASSETS)
+
+# Include dependency files if they exist
+# --------------------------------------
+
+-include $(DEPS)

--- a/include/nds.h
+++ b/include/nds.h
@@ -38,6 +38,7 @@
 /// - @ref nds/memory.h "NDS and GBA header structure"
 /// - @ref nds/dma.h "Direct Memory Access"
 /// - @ref nds/ndma.h "DSi New Direct Memory Access"
+/// - @ref nds/nwram.h "DSi New WRAM"
 ///
 /// @section filesystem_api Storage Access
 /// - @ref nds/card.h "Slot-1 access functions"
@@ -112,6 +113,7 @@ extern "C" {
 #include <nds/memory.h>
 #include <nds/ndma.h>
 #include <nds/ndstypes.h>
+#include <nds/nwram.h>
 #include <nds/sha1.h>
 #include <nds/system.h>
 #include <nds/timers.h>

--- a/include/nds.h
+++ b/include/nds.h
@@ -62,6 +62,10 @@
 /// - @ref nds/arm9/keyboard.h "Keyboard"
 /// - @ref nds/arm9/console.h "Console and Debug Printing"
 ///
+/// @section dsp_api DSi Teak DSP Utilities
+/// - @ref nds/arm9/teak/dsp.h "DSP general utilities"
+/// - @ref nds/arm9/teak/tlf.h "TLF format description"
+///
 /// @section utility_api Utility
 /// - @ref nds/arm9/decompress.h "Decompression"
 /// - @ref nds/arm9/image.h "Image Manipulation"
@@ -146,6 +150,8 @@ extern "C" {
 #    include <nds/arm9/video.h>
 #    include <nds/arm9/videoGL.h>
 #    include <nds/arm9/window.h>
+#    include <nds/arm9/teak/dsp.h>
+#    include <nds/arm9/teak/tlf.h>
 #endif // ARM9
 
 #ifdef ARM7

--- a/include/nds/arm9/teak/dsp.h
+++ b/include/nds/arm9/teak/dsp.h
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+// Copyright (C) 2023 Antonio Niño Díaz
+
+#ifndef LIBNDS_NDS_ARM9_TEAK_DSP_H__
+#define LIBNDS_NDS_ARM9_TEAK_DSP_H__
+
+#include <nds/ndstypes.h>
+
+/// @file nds/arm9/teak/dsp.h
+///
+/// @brief DSP general utilities.
+///
+/// This file contains general definitions and helpers to use the DSP of the
+/// DSi.
+
+#define DSP_MEM_ADDR_TO_DSP(addr)       ((u16)(((u32)(addr)) >> 1))
+#define DSP_MEM_ADDR_TO_CPU(addr)       ((u32)((addr) << 1))
+
+#define DSP_MEM_32BIT_TO_DSP(x)         (u32)(((u32)(x) >> 16) | ((u32)(x) << 16))
+
+/// DSP Transfer Data Read FIFO (R/W)
+#define REG_DSP_PDATA           (*(vu16 *)(0x04004300))
+
+/// DSP Transfer Address (W)
+#define REG_DSP_PADR            (*(vu16 *)(0x04004304))
+
+/// DSP Configuration (R/W)
+#define REG_DSP_PCFG            (*(vu16 *)0x4004308)
+
+#define DSP_PCFG_RESET          1
+
+#define DSP_PCFG_AUTOINC        (1 << 1)
+
+typedef enum
+{
+    DSP_PCFG_RLEN_1 = 0,
+    DSP_PCFG_RLEN_8 = 1,
+    DSP_PCFG_RLEN_16 = 2,
+    DSP_PCFG_RLEN_FREE = 3
+} DSP_PCFG_RLEN;
+
+#define DSP_PCFG_RLEN_SHIFT     2
+#define DSP_PCFG_RLEN_MASK      (3 << DSP_PCFG_RLEN_SHIFT)
+#define DSP_PCFG_RLEN(x)        ((x) << DSP_PCFG_RLEN_SHIFT)
+
+#define DSP_PCFG_RSTART         (1 << 4)
+
+#define DSP_PCFG_IE_REP_SHIFT   9
+
+#define DSP_PCFG_IE_REP0        (1 << DSP_PCFG_IE_REP_SHIFT)
+#define DSP_PCFG_IE_REP1        (1 << (DSP_PCFG_IE_REP_SHIFT + 1))
+#define DSP_PCFG_IE_REP2        (1 << (DSP_PCFG_IE_REP_SHIFT + 2))
+
+typedef enum
+{
+    DSP_PCFG_MEMSEL_DATA = 0,
+    DSP_PCFG_MEMSEL_MMIO = 1,
+    DSP_PCFG_MEMSEL_PROG = 5
+} DSP_PCFG_MEMSEL;
+
+#define DSP_PCFG_MEMSEL_SHIFT   12
+#define DSP_PCFG_MEMSEL_MASK    (0xF << DSP_PCFG_MEMSEL_SHIFT)
+#define DSP_PCFG_MEMSEL(x)      ((x) << DSP_PCFG_MEMSEL_SHIFT)
+
+/// DSP Status (R)
+#define REG_DSP_PSTS            (*(vu16 *)0x400430C)
+
+#define DSP_PSTS_RD_XFER_BUSY   (1 << 0)
+#define DSP_PSTS_WR_XFER_BUSY   (1 << 1)
+#define DSP_PSTS_PERI_RESET     (1 << 2)
+#define DSP_PSTS_RD_FIFO_FULL   (1 << 5)
+#define DSP_PSTS_RD_FIFO_READY  (1 << 6)
+#define DSP_PSTS_WR_FIFO_FULL   (1 << 7)
+#define DSP_PSTS_WR_FIFO_EMPTY  (1 << 8)
+
+#define DSP_PSTS_REP_NEW_SHIFT  10
+
+#define DSP_PSTS_REP0_NEW       (1 << DSP_PSTS_REP_NEW_SHIFT)
+#define DSP_PSTS_REP1_NEW       (1 << (DSP_PSTS_REP_NEW_SHIFT + 1))
+#define DSP_PSTS_REP2_NEW       (1 << (DSP_PSTS_REP_NEW_SHIFT + 2))
+
+#define DSP_PSTS_CMD_UNREAD_SHIFT 13
+
+#define DSP_PSTS_CMD0_UNREAD    (1 << DSP_PSTS_CMD_UNREAD_SHIFT)
+#define DSP_PSTS_CMD1_UNREAD    (1 << (DSP_PSTS_CMD_UNREAD_SHIFT + 1))
+#define DSP_PSTS_CMD2_UNREAD    (1 << (DSP_PSTS_CMD_UNREAD_SHIFT + 2))
+
+/// ARM9-to-DSP Semaphore (R/W)
+#define REG_DSP_PSEM            (*(vu16 *)0x4004310)
+/// DSP-to-ARM9 Semaphore Mask (R/W)
+#define REG_DSP_PMASK           (*(vu16 *)0x4004314)
+/// DSP-to-ARM9 Semaphore Clear (W)
+#define REG_DSP_PCLEAR          (*(vu16 *)0x4004318)
+/// DSP-to-ARM9 Semaphore Data (R)
+#define REG_DSP_SEM             (*(vu16 *)0x400431C)
+
+/// DSP Command Register 0 (R/W) (ARM9 to DSP)
+#define REG_DSP_CMD0            (*(vu16 *)0x4004320)
+/// DSP Reply Register 0 (R) (DSP to ARM9)
+#define REG_DSP_REP0            (*(vu16 *)0x4004324)
+
+/// DSP Command Register 1 (R/W) (ARM9 to DSP)
+#define REG_DSP_CMD1            (*(vu16 *)0x4004328)
+/// DSP Reply Register 1 (R) (DSP to ARM9)
+#define REG_DSP_REP1            (*(vu16 *)0x400432C)
+
+/// DSP Command Register 2 (R/W) (ARM9 to DSP)
+#define REG_DSP_CMD2            (*(vu16 *)0x4004330)
+/// DSP Reply Register 2 (R) (DSP to ARM9)
+#define REG_DSP_REP2            (*(vu16 *)0x4004334)
+
+/// Function that executes a delay of a few cycles.
+void dspSpinWait(void);
+
+void dspSetBlockReset(bool reset);
+void dspSetClockEnabled(bool enabled);
+void dspResetInterface(void);
+void dspSetCoreResetOn(void);
+void dspSetCoreResetOff(u16 repIrqMask);
+void dspPowerOn(void);
+void dspPowerOff(void);
+
+/// This powers on the DSP, loads a TLF file and executes it.
+///
+/// The user must allocate NWRAM to the ARM9 before calling this function by
+/// using nwramSetBlockMapping(). Remember that the default MPU setup only
+/// allows mapping it to the range 0x03000000 - 0x03800000.
+///
+/// @param tlf Pointer to the TLF data in RAM.
+/// @return true on success.
+bool dspExecuteTLF(const void *tlf);
+
+/// Sends data using one of the CMD registers.
+///
+/// This function waits until the previous value has been read by the DSP.
+///
+/// @param id ID of the CMD register (0 to 2).
+/// @param data Data to send.
+void dspSendData(int id, u16 data);
+
+/// Checks if a CMD register is available to receive new data.
+///
+/// @param id ID of the CMD register (0 to 2).
+/// @return true if it is available.
+bool dspSendDataReady(int id);
+
+/// Receives data from one of the REP registers.
+///
+/// This function waits until there is a value to be read.
+///
+/// @param id ID of the REP register (0 to 2).
+/// @return Received data.
+u16 dspReceiveData(int id);
+
+/// Checks if a REP register has any data available.
+///
+/// @param id ID of the REP register (0 to 2).
+/// @return true if there is data to be read.
+bool dspReceiveDataReady(int id);
+
+static inline void dspSetSemaphore(u16 mask)
+{
+    REG_DSP_PSEM = mask;
+}
+
+static inline void dspSetSemaphoreMask(u16 mask)
+{
+    REG_DSP_PMASK = mask;
+}
+
+static inline void dspClearSemaphore(u16 mask)
+{
+    REG_DSP_PCLEAR = mask;
+}
+
+static inline u16 dspGetSemaphore(void)
+{
+    dspSpinWait();
+    return REG_DSP_SEM;
+}
+
+#endif // LIBNDS_NDS_ARM9_TEAK_DSP_H__

--- a/include/nds/arm9/teak/tlf.h
+++ b/include/nds/arm9/teak/tlf.h
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2023 Antonio Niño Díaz
+
+#ifndef LIBNDS_NDS_ARM9_TEAK_TLF_H__
+#define LIBNDS_NDS_ARM9_TEAK_TLF_H__
+
+#include <stdint.h>
+
+/// @file nds/arm9/teak/tlf.h
+///
+/// @brief TLF (Teak Loadable Format) description and helpers.
+///
+/// TLF is a format designed to hold executable files for the Teak DSP of the
+/// DSi. It is a simplified version of the CDC/DSP1 format.
+///
+/// General structure of the file:
+///
+///     +======================+
+///     | TLF header           | It specifies the number of sections in the file.
+///     +======================+
+///     | TLF section header 0 | As many section headers as sections.
+///     +----------------------+
+///     | TLF section header 1 |
+///     +----------------------+
+///     | TLF section header 2 |
+///     +======================+
+///     | Section data 0       | Data of each section, one after the other.
+///     +----------------------+
+///     | Section data 1       |
+///     +----------------------+
+///     | Section data 2       |
+///     +======================+
+///
+/// TLF header: General information about the file.
+///
+///     +--------------------+-------------+--------------------------------+
+///     | Field              | Type        | Notes                          |
+///     +====================+=============+================================+
+///     | Magic              | uint32_t    | 0x30464C54 == 'TLF0'           |
+///     +--------------------+-------------+--------------------------------+
+///     | Version            | uint8_t     | Current version: 0             |
+///     +--------------------+-------------+--------------------------------+
+///     | Number of sections | uint8_t     |                                |
+///     +--------------------+-------------+--------------------------------+
+///     | Padding            | uint8_t * 2 | Unused, set to zero.           |
+///     +====================+=============+================================+
+///
+/// TLF section header: Saved right after the TLF header. This is repeated for
+/// all sections stored in the file.
+///
+///     +====================+=============+================================+
+///     | Address            | uint16_t    | As seen by the DSP (in words). |
+///     +--------------------+-------------+--------------------------------+
+///     | Size (in bytes)    | uint16_t    |                                |
+///     +--------------------+-------------+--------------------------------+
+///     | Section type       | uint8_t     | 0 = code, 1 = data.            |
+///     +--------------------+-------------+--------------------------------+
+///     | Padding            | uint8_t * 3 | Unused, set to zero.           |
+///     +--------------------+-------------+--------------------------------+
+///     | Data offset        | uint32_t    | Offset to the section data     |
+///     |                    |             | from the start of the file.    |
+///     +====================+=============+================================+
+///
+/// Section data: The data of the sections is stored right after the array of
+/// TLF section headers.
+
+/// TLF section header description
+typedef struct {
+    uint16_t address;       ///< Address as seen from the DSP (in words)
+    uint16_t size;          ///< Size in bytes
+    uint8_t type;           ///< TLF_SEGMENT_CODE or TLF_SEGMENT_DATA
+    uint8_t padding[3];     ///< Unused. Set to zero
+    uint32_t data_offset;   ///< Offset of the file to the data of the section
+} tlf_section_header;
+
+static_assert(sizeof(tlf_section_header) == 12);
+
+/// The section contains code
+#define TLF_SEGMENT_CODE 0
+/// The section contains data
+#define TLF_SEGMENT_DATA 1
+
+/// TLF file header
+typedef struct {
+    uint32_t magic;               ///< Magic number: TLF_MAGIC
+    uint8_t version;              ///< Version number (currently 0)
+    uint8_t num_sections;         ///< Number of sections in the file
+    uint8_t padding[2];           ///< Unused. Set to zero
+    tlf_section_header section[]; ///< Array of section headers
+} tlf_header;
+
+/// Magic value of the TLF header file. Same as 'TLF0'
+#define TLF_MAGIC 0x30464C54
+
+static_assert(sizeof(tlf_header) == 8);
+
+#endif // LIBNDS_NDS_ARM9_TEAK_TLF_H__

--- a/include/nds/memory.h
+++ b/include/nds/memory.h
@@ -49,15 +49,33 @@
 #define ARM7_OWNS_CARD                      EXMEMCNT_CARD_ARM7
 #define ARM7_OWNS_ROM                       EXMEMCNT_CART_ARM7
 
-#define REG_MBK1    ((vu8 *)0x04004040) // WRAM_A 0..3
-#define REG_MBK2    ((vu8 *)0x04004044) // WRAM_B 0..3
-#define REG_MBK3    ((vu8 *)0x04004048) // WRAM_B 4..7
-#define REG_MBK4    ((vu8 *)0x0400404C) // WRAM_C 0..3
-#define REG_MBK5    ((vu8 *)0x04004050) // WRAM_C 4..7
-#define REG_MBK6    (*(vu32 *)0x04004054)
-#define REG_MBK7    (*(vu32 *)0x04004058)
-#define REG_MBK8    (*(vu32 *)0x0400405C)
-#define REG_MBK9    (*(vu32 *)0x04004060)
+#define REG_MBK1                    ((vu8 *)0x04004040) // WRAM_A 0..3
+#define REG_MBK2                    ((vu8 *)0x04004044) // WRAM_B 0..3
+#define REG_MBK3                    ((vu8 *)0x04004048) // WRAM_B 4..7
+#define REG_MBK4                    ((vu8 *)0x0400404C) // WRAM_C 0..3
+#define REG_MBK5                    ((vu8 *)0x04004050) // WRAM_C 4..7
+#define REG_MBK6                    (*(vu32 *)0x04004054)
+
+#define MBK6_START_ADDR_MASK        0x00000FF0
+#define MBK6_START_ADDR_SHIFT       4
+#define MBK6_IMAGE_SIZE_SHIFT       12
+#define MBK6_END_ADDR_SHIFT         20
+
+#define REG_MBK7                    (*(vu32 *)0x04004058)
+
+#define MBK7_START_ADDR_MASK        0x00000FF8
+#define MBK7_START_ADDR_SHIFT       3
+#define MBK7_IMAGE_SIZE_SHIFT       12
+#define MBK7_END_ADDR_SHIFT         19
+
+#define REG_MBK8                    (*(vu32 *)0x0400405C)
+
+#define MBK8_START_ADDR_MASK        0x00000FF8
+#define MBK8_START_ADDR_SHIFT       3
+#define MBK8_IMAGE_SIZE_SHIFT       12
+#define MBK8_END_ADDR_SHIFT         19
+
+#define REG_MBK9                    (*(vu32 *)0x04004060)
 
 // Protection register (write-once sadly)
 #ifdef ARM7

--- a/include/nds/nwram.h
+++ b/include/nds/nwram.h
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+// Copyright (c) 2023 Antonio Niño Díaz
+
+#ifndef LIBNDS_NDS_NWRAM_H__
+#define LIBNDS_NDS_NWRAM_H__
+
+#include <stdbool.h>
+
+#include <nds/ndstypes.h>
+
+/// @file nds/nwram.h
+///
+/// @brief New WRAM utilities.
+
+/// Available NWRAM blocks.
+typedef enum
+{
+    NWRAM_BLOCK_A = 0, ///< NWRAM block A
+    NWRAM_BLOCK_B = 1, ///< NWRAM block B
+    NWRAM_BLOCK_C = 2  ///< NWRAM block C
+} NWRAM_BLOCK;
+
+/// Possible image sizes of a NWRAM block
+typedef enum
+{
+    NWRAM_BLOCK_IMAGE_SIZE_32K = 0, ///< 32 KB
+    NWRAM_BLOCK_IMAGE_SIZE_64K,     ///< 64 KB
+    NWRAM_BLOCK_IMAGE_SIZE_128K,    ///< 128 KB
+    NWRAM_BLOCK_IMAGE_SIZE_256K,    ///< 256 KB
+} NWRAM_BLOCK_IMAGE_SIZE;
+
+/// Base address of NWRAM
+#define NWRAM_BASE                  0x03000000
+
+// NWRAM A
+// =======
+
+#define NWRAM_A_SLOT_SIZE           0x10000
+#define NWRAM_A_SLOT_SHIFT          16
+#define NWRAM_A_SLOT_COUNT          4
+
+#define NWRAM_A_ADDRESS_MAX         0x03FF0000
+
+#define NWRAM_A_SLOT_OFFSET(i)      ((i) << 2)
+#define NWRAM_A_SLOT_ENABLE         0x80
+
+/// Possible owners of NWRAM A slots
+typedef enum
+{
+    NWRAM_A_SLOT_MASTER_ARM9 = 0, ///< The ARM9 is the owner
+    NWRAM_A_SLOT_MASTER_ARM7 = 1  ///< The ARM7 is the owner
+} NWRAM_A_SLOT_MASTER;
+
+// NWRAM B and C
+// =============
+
+#define NWRAM_BC_SLOT_SIZE          0x8000
+#define NWRAM_BC_SLOT_SHIFT         15
+#define NWRAM_BC_SLOT_COUNT         8
+
+#define NWRAM_BC_ADDRESS_MAX        0x03FF8000
+
+#define NWRAM_BC_SLOT_OFFSET(i)     ((i) << 2)
+#define NWRAM_BC_SLOT_ENABLE        0x80
+
+/// Possible owners of NWRAM C slots
+typedef enum
+{
+    NWRAM_B_SLOT_MASTER_ARM9 = 0,    ///< The ARM9 is the owner
+    NWRAM_B_SLOT_MASTER_ARM7 = 1,    ///< The ARM7 is the owner
+    NWRAM_B_SLOT_MASTER_DSP_CODE = 2 ///< The DSP is the owner. Used for code.
+} NWRAM_B_SLOT_MASTER;
+
+/// Possible owners of NWRAM C slots
+typedef enum
+{
+    NWRAM_C_SLOT_MASTER_ARM9 = 0,    ///< The ARM9 is the owner
+    NWRAM_C_SLOT_MASTER_ARM7 = 1,    ///< The ARM7 is the owner
+    NWRAM_C_SLOT_MASTER_DSP_DATA = 2 ///< The DSP is the owner. Used for data.
+} NWRAM_C_SLOT_MASTER;
+
+/// Returns the address of a NWRAM block that has been mapped to a CPU.
+///
+/// @param block One of NWRAM_BLOCK.
+/// @return The address.
+u32 nwramGetBlockAddress(NWRAM_BLOCK block);
+
+/// Maps a NWRAM block to a CPU to the specified address and length.
+///
+/// @param block One of NWRAM_BLOCK.
+/// @param start The base address. Only 0x3000000 to 0x3800000 available.
+/// @param length Length of the block.
+/// @param imageSize Size of the block.
+void nwramSetBlockMapping(NWRAM_BLOCK block, u32 start, u32 length,
+                          NWRAM_BLOCK_IMAGE_SIZE imageSize);
+
+#ifdef ARM9
+
+/// Maps a slot of WRAM slot A to the specified CPU.
+///
+/// @param slot Slot index (0 to 3).
+/// @param master Owner of the slot (ARM7, ARM9 or DSP).
+/// @param offset Offset of the slot.
+/// @param enable true to enable the slot, false to disable it.
+void nwramMapWramASlot(int slot, NWRAM_A_SLOT_MASTER master, int offset, bool enable);
+
+/// Maps a slot of WRAM slot B to the specified CPU.
+///
+/// @param slot Slot index (0 to 3).
+/// @param master Owner of the slot (ARM7, ARM9 or DSP).
+/// @param offset Offset of the slot.
+/// @param enable true to enable the slot, false to disable it.
+void nwramMapWramBSlot(int slot, NWRAM_B_SLOT_MASTER master, int offset, bool enable);
+
+/// Maps a slot of WRAM slot C to the specified CPU.
+///
+/// @param slot Slot index (0 to 3).
+/// @param master Owner of the slot (ARM7, ARM9 or DSP).
+/// @param offset Offset of the slot.
+/// @param enable true to enable the slot, false to disable it.
+void nwramMapWramCSlot(int slot, NWRAM_C_SLOT_MASTER master, int offset, bool enable);
+
+#endif // ARM9
+
+#endif // LIBNDS_NDS_NWRAM_H__

--- a/include/nds/system.h
+++ b/include/nds/system.h
@@ -457,11 +457,49 @@ void resetARM9(u32 address);
 
 // DSi SCFG registers
 
-#define REG_SCFG_ROM            *(vu16 *)0x4004000
-#define REG_SCFG_CLK            *(vu16 *)0x4004004
-#define REG_SCFG_RST            *(vu16 *)0x4004006
-#define REG_SCFG_EXT            *(vu32 *)0x4004008
-#define REG_SCFG_MC             *(vu16 *)0x4004010
+// SCFG_xxROM
+// ==========
+
+#define REG_SCFG_ROM            (*(vu16 *)0x4004000)
+
+#ifdef ARM7
+#define REG_SCFG_A9ROM          (*(vu8 *)0x4004000)
+#define REG_SCFG_A7ROM          (*(vu8 *)0x4004001)
+#endif // ARM7
+
+// SCFG_CLK
+// ========
+
+#define REG_SCFG_CLK            (*(vu16 *)0x4004004)
+
+#ifdef ARM9
+#define SCFG_CLK_ARM9_TWL       BIT(0)
+#define SCFG_CLK_DSP            BIT(1)
+#define SCFG_CLK_CAMERA_IF      BIT(2)
+#define SCFG_CLK_NWRAM          BIT(7) // Read only, set by ARM7
+#define SCFG_CLK_CAMERA_EXT     BIT(8)
+#endif // ARM9
+
+#ifdef ARM7
+#define SCFG_CLK_SDMMC          BIT(0)
+#define SCFG_CLK_NWRAM          BIT(7)
+#define SCFG_CLK_TOUCH          BIT(8)
+#endif // ARM7
+
+// SCFG_RST
+// ========
+
+#define REG_SCFG_RST            (*(vu16 *)0x4004006)
+
+#ifdef ARM9
+#define SCFG_RST_DSP_APPLY      (0 << 0)
+#define SCFG_RST_DSP_RELEASE    (1 << 0)
+#endif // ARM9
+
+// SCFG_MC
+// =======
+
+#define REG_SCFG_MC             (*(vu16 *)0x4004010)
 
 #define SCFG_MC_EJECTED         0x01
 #define SCFG_MC_PWR_MASK        0x0C
@@ -470,14 +508,31 @@ void resetARM9(u32 address);
 #define SCFG_MC_PWR_ON          0x08
 #define SCFG_MC_PWR_REQUEST_OFF 0x0C
 
+// SCFG_EXT
+// ========
+
+#define REG_SCFG_EXT            (*(vu32 *)0x4004008)
+
+#ifdef ARM9
+#define SCFG_EXT_DMA            BIT(0)
+#define SCFG_EXT_GEOMETRY       BIT(1)
+#define SCFG_EXT_RENDERER       BIT(2)
+#define SCFG_EXT_2D             BIT(3)
+#define SCFG_EXT_DIVIDER        BIT(4)
+#define SCFG_EXT_CARD           BIT(7)
+#define SCFG_EXT_INTERRUPT      BIT(8)
+#define SCFG_EXT_LCD            BIT(12)
+#define SCFG_EXT_VRAM           BIT(13)
+#define SCFG_EXT_RAM_DEBUG      BIT(14)
+#define SCFG_EXT_RAM_TWL        BIT(15)
+#define SCFG_EXT_NDMA           BIT(16)
+#define SCFG_EXT_CAMERA         BIT(17)
+#define SCFG_EXT_DSP            BIT(18)
+#define SCFG_EXT_MBK_RAM        BIT(25)
+#define SCFG_EXT_SCFG_MBK_REG   BIT(31)
+#endif // ARM9
+
 #ifdef ARM7
-#define REG_SCFG_A9ROM          *(vu8 *)0x4004000
-#define REG_SCFG_A7ROM          *(vu8 *)0x4004001
-
-#define SCFG_CLK_SDMMC          BIT(0)
-#define SCFG_CLK_MBK_RAM        BIT(7)
-#define SCFG_CLK_TOUCH          BIT(8)
-
 #define SCFG_EXT_DMA            BIT(0)
 #define SCFG_EXT_SOUND_DMA      BIT(1)
 #define SCFG_EXT_SOUND          BIT(2)
@@ -500,32 +555,5 @@ void resetARM9(u32 address);
 #define SCFG_EXT_MBK_RAM        BIT(25)
 #define SCFG_EXT_SCFG_MBK_REG   BIT(31)
 #endif // ARM7
-
-#ifdef ARM9
-#define SCFG_CLK_ARM9_TWL       BIT(0)
-#define SCFG_CLK_DSP            BIT(1)
-#define SCFG_CLK_CAMERA_IF      BIT(2)
-#define SCFG_CLK_MBK_RAM        BIT(7)
-#define SCFG_CLK_CAMERA_EXT     BIT(8)
-
-#define SCFG_RST_DSP            BIT(0)
-
-#define SCFG_EXT_DMA            BIT(0)
-#define SCFG_EXT_GEOMETRY       BIT(1)
-#define SCFG_EXT_RENDERER       BIT(2)
-#define SCFG_EXT_2D             BIT(3)
-#define SCFG_EXT_DIVIDER        BIT(4)
-#define SCFG_EXT_CARD           BIT(7)
-#define SCFG_EXT_INTERRUPT      BIT(8)
-#define SCFG_EXT_LCD            BIT(12)
-#define SCFG_EXT_VRAM           BIT(13)
-#define SCFG_EXT_RAM_DEBUG      BIT(14)
-#define SCFG_EXT_RAM_TWL        BIT(15)
-#define SCFG_EXT_NDMA           BIT(16)
-#define SCFG_EXT_CAMERA         BIT(17)
-#define SCFG_EXT_DSP            BIT(18)
-#define SCFG_EXT_MBK_RAM        BIT(25)
-#define SCFG_EXT_SCFG_MBK_REG   BIT(31)
-#endif // ARM9
 
 #endif // LIBNDS_NDS_SYSTEM_H__

--- a/include/teak/apbp.h
+++ b/include/teak/apbp.h
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+
+#ifndef LIBTEAK_APBP_H__
+#define LIBTEAK_APBP_H__
+
+#include <teak/types.h>
+
+// Host Port Interface (APBP aka HPI)
+
+/// APBP DSP-to-ARM Reply 0 (R/W)
+#define REG_APBP_REP0                   (*(vu16 *)0x80C0)
+/// APBP ARM-to-DSP Command 0 (R)
+#define REG_APBP_CMD0                   (*(vu16 *)0x80C2)
+
+/// APBP DSP-to-ARM Reply 1 (R/W)
+#define REG_APBP_REP1                   (*(vu16 *)0x80C4)
+/// APBP ARM-to-DSP Command 1 (R)
+#define REG_APBP_CMD1                   (*(vu16 *)0x80C6)
+
+/// APBP DSP-to-ARM Reply 2 (R/W)
+#define REG_APBP_REP2                   (*(vu16 *)0x80C8)
+/// APBP ARM-to-DSP Command 2 (R)
+#define REG_APBP_CMD2                   (*(vu16 *)0x80CA)
+
+/// APBP DSP-to-ARM Semaphore Set Flags (R/W)
+#define REG_APBP_PSEM                   (*(vu16 *)0x80CC)
+/// APBP ARM-to-DSP Semaphore Interrupt Mask (R/W)
+#define REG_APBP_PMASK                  (*(vu16 *)0x80CE)
+/// APBP ARM-to-DSP Semaphore Ack Flags (W?)
+#define REG_APBP_PCLEAR                 (*(vu16 *)0x80D0)
+/// APBP ARM-to-DSP Semaphore Get Flags (R)
+#define REG_APBP_SEM                    (*(vu16 *)0x80D2)
+
+/// APBP Control (R/W)
+#define REG_APBP_CONTROL                (*(vu16 *)0x80D4)
+
+#define APBP_CONTROL_ARM_BIG_ENDIAN     BIT(2)
+#define APBP_CONTROL_IRQ_CMD0_DISABLE   BIT(8)
+#define APBP_CONTROL_IRQ_CMD1_DISABLE   BIT(12)
+#define APBP_CONTROL_IRQ_CMD2_DISABLE   BIT(13)
+
+/// APBP DSP-side Status (R)
+#define REG_APBP_STAT                   (*(vu16 *)0x80D6)
+
+#define APBP_STAT_REP0_UNREAD           BIT(5)
+#define APBP_STAT_REP1_UNREAD           BIT(6)
+#define APBP_STAT_REP2_UNREAD           BIT(7)
+
+#define APBP_STAT_CMD0_NEW              BIT(8)
+#define APBP_STAT_CMD1_NEW              BIT(12)
+#define APBP_STAT_CMD2_NEW              BIT(13)
+
+#define APBP_STAT_SEM_FLAG              BIT(9)
+
+/// APBP ARM-side Status (mirror of ARM9 Port 400430Ch) (R)
+#define REG_APBP_ARM_STAT               (*(vu16 *)0x80D8)
+
+#define APBP_ARM_STAT_RD_XFER_BUSY      BIT(0)
+
+#define APBP_ARM_STAT_WR_XFER_BUSY      BIT(1)
+
+#define APBP_ARM_STAT_PERI_RESET        BIT(2)
+
+#define APBP_ARM_STAT_RD_FIFO_FULL      BIT(5)
+#define APBP_ARM_STAT_RD_FIFO_READY     BIT(6)
+#define APBP_ARM_STAT_WR_FIFO_FULL      BIT(7)
+#define APBP_ARM_STAT_WR_FIFO_EMPTY     BIT(8)
+
+#define APBP_ARM_STAT_REP_NEW_SHIFT     10
+
+#define APBP_ARM_STAT_REP0_NEW          (1 << APBP_ARM_STAT_REP_NEW_SHIFT)
+#define APBP_ARM_STAT_REP1_NEW          (1 << (APBP_ARM_STAT_REP_NEW_SHIFT + 1))
+#define APBP_ARM_STAT_REP2_NEW          (1 << (APBP_ARM_STAT_REP_NEW_SHIFT + 2))
+
+#define APBP_ARM_STAT_CMD_UNREAD_SHIFT  13
+
+#define APBP_ARM_STAT_CMD0_UNREAD       (1 << APBP_ARM_STAT_CMD_UNREAD_SHIFT)
+#define APBP_ARM_STAT_CMD1_UNREAD       (1 << (APBP_ARM_STAT_CMD_UNREAD_SHIFT + 1))
+#define APBP_ARM_STAT_CMD2_UNREAD       (1 << (APBP_ARM_STAT_CMD_UNREAD_SHIFT + 2))
+
+static inline void apbpSetSemaphore(uint16_t mask)
+{
+    REG_APBP_PSEM = mask;
+}
+
+static inline void apbpSetSemaphoreMask(uint16_t mask)
+{
+    REG_APBP_PMASK = mask;
+}
+
+static inline void apbpClearSemaphore(uint16_t mask)
+{
+    REG_APBP_PCLEAR = mask;
+}
+
+static inline uint16_t apbpGetSemaphore(void)
+{
+    return REG_APBP_SEM;
+}
+
+void apbpSendData(uint16_t id, uint16_t data);
+
+uint16_t apbpReceiveData(uint16_t id);
+
+#endif // LIBTEAK_APBP_H__

--- a/include/teak/cpu.h
+++ b/include/teak/cpu.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+
+#ifndef LIBTEAK_CPU_H__
+#define LIBTEAK_CPU_H__
+
+void cpuDisableIrqs(void);
+void cpuEnableIrqs(void);
+
+void cpuDisableInt0(void);
+void cpuEnableInt0(void);
+
+void cpuDisableInt1(void);
+void cpuEnableInt1(void);
+
+void cpuDisableInt2(void);
+void cpuEnableInt2(void);
+
+void cpuDisableVInt(void);
+void cpuEnableVInt(void);
+
+#endif // LIBTEAK_CPU_H__

--- a/include/teak/icu.h
+++ b/include/teak/icu.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+// Copyright (c) 2023 Antonio Niño Díaz
+
+#ifndef LIBTEAK_ICU_H__
+#define LIBTEAK_ICU_H__
+
+#include <teak/types.h>
+
+#define ICU_IRQ_MASK_SWI(n)             BIT(n) // 0 to 8
+#define ICU_IRQ_MASK_TMR1               BIT(9)
+#define ICU_IRQ_MASK_TMR0               BIT(10)
+#define ICU_IRQ_MASK_BTDMP0             BIT(11)
+#define ICU_IRQ_MASK_BTDMP1             BIT(12)
+#define ICU_IRQ_MASK_SIO                BIT(13)
+#define ICU_IRQ_MASK_APBP               BIT(14)
+#define ICU_IRQ_MASK_DMA                BIT(15)
+
+/// ICU Interrupt Pending Flags (R)
+#define REG_ICU_IRQ_PENDING             (*(vu16 *)0x8200)
+/// ICU Interrupt Acknowledge (W)
+#define REG_ICU_IRQ_ACK                 (*(vu16 *)0x8202)
+/// ICU Interrupt Manual Trigger (R/W)
+#define REG_ICU_IRQ_REQ                 (*(vu16 *)0x8204)
+/// ICU Enable Interrupt routing to core interrupt 0 (R/W)
+#define REG_ICU_IRQ_INT0                (*(vu16 *)0x8206)
+/// ICU Enable Interrupt routing to core interrupt 1 (R/W)
+#define REG_ICU_IRQ_INT1                (*(vu16 *)0x8208)
+/// ICU Enable Interrupt routing to core interrupt 2 (R/W)
+#define REG_ICU_IRQ_INT2                (*(vu16 *)0x820A)
+/// ICU Enable Interrupt routing to vectored interrupt (R/W)
+#define REG_ICU_IRQ_VINT                (*(vu16 *)0x820C)
+/// ICU Interrupt Trigger mode (0=Level, 1=Edge) (R/W)
+#define REG_ICU_IRQ_MODE                (*(vu16 *)0x820E)
+/// ICU Interrupt Polarity (0=Normal, 1=Invert) (R/W)
+#define REG_ICU_IRQ_POLARITY            (*(vu16 *)0x8210)
+
+/// ICU Vectored Interrupt 0..15 Address, bit16-31 (R/W)
+#define REG_ICU_VINT_ADDR_HI(x)         (*(vu16 *)(0x8212 + (x) * 4))
+/// ICU Vectored Interrupt 0..15 Address, bit0-15 (R/W)
+#define REG_ICU_VINT_ADDR_LO(x)         (*(vu16 *)(0x8214 + (x) * 4))
+
+#define ICU_VINT_ADDR_HI(address)       (((address) >> 16) & 0x3)
+#define ICU_VINT_ADDR_CTX_SWITCH        BIT(15)
+
+#define ICU_VINT_ADDR_LO(address)       ((address) & 0xFFFF)
+
+/// ICU Interrupt Master Disable (R/W)
+#define REG_ICU_IRQ_DISABLE             (*(vu16 *)0x8252)
+
+void icuInit(void);
+
+#endif // LIBTEAK_ICU_H__

--- a/include/teak/teak.h
+++ b/include/teak/teak.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+// Copyright (c) 2023 Antonio Niño Díaz
+
+#ifndef LIBTEAK_TEAK_H__
+#define LIBTEAK_TEAK_H__
+
+#include <teak/apbp.h>
+#include <teak/cpu.h>
+#include <teak/icu.h>
+#include <teak/types.h>
+
+#endif // LIBTEAK_TEAK_H__

--- a/include/teak/types.h
+++ b/include/teak/types.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2023 Antonio Niño Díaz
+
+#ifndef LIBTEAK_TYPES_H__
+#define LIBTEAK_TYPES_H__
+
+#include <stdint.h>
+
+#define BIT(n) (1 << (n))
+
+/// 8 bit volatile unsigned integer.
+typedef volatile uint8_t vuint8;
+/// 16 bit volatile unsigned integer.
+typedef volatile uint16_t vuint16;
+/// 32 bit volatile unsigned integer.
+typedef volatile uint32_t vuint32;
+/// 64 bit volatile unsigned integer.
+typedef volatile uint64_t vuint64;
+
+/// 8 bit volatile signed integer.
+typedef volatile int8_t vint8;
+/// 16 bit volatile signed integer.
+typedef volatile int16_t vint16;
+/// 32 bit volatile signed integer.
+typedef volatile int32_t vint32;
+/// 64 bit volatile signed integer.
+typedef volatile int64_t vint64;
+
+/// 8 bit unsigned integer.
+typedef uint8_t u8;
+/// 16 bit unsigned integer.
+typedef uint16_t u16;
+/// 32 bit unsigned integer.
+typedef uint32_t u32;
+/// 64 bit unsigned integer.
+typedef uint64_t u64;
+
+/// 8 bit signed integer.
+typedef int8_t s8;
+/// 16 bit signed integer.
+typedef int16_t s16;
+/// 32 bit signed integer.
+typedef int32_t s32;
+/// 64 bit signed integer.
+typedef int64_t s64;
+
+/// 8 bit volatile unsigned integer.
+typedef volatile u8 vu8;
+/// 16 bit volatile unsigned integer.
+typedef volatile u16 vu16;
+/// 32 bit volatile unsigned integer.
+typedef volatile u32 vu32;
+/// 64 bit volatile unsigned integer.
+typedef volatile u64 vu64;
+
+/// 8 bit volatile signed integer.
+typedef volatile s8 vs8;
+/// 16 bit volatile signed integer.
+typedef volatile s16 vs16;
+/// 32 bit volatile signed integer.
+typedef volatile s32 vs32;
+/// 64 bit volatile signed integer.
+typedef volatile s64 vs64;
+
+#endif // LIBTEAK_TYPES_H__

--- a/source/arm9/teak/dsp.twl.c
+++ b/source/arm9/teak/dsp.twl.c
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+// Copyright (C) 2023 Antonio Niño Díaz
+
+#include <nds.h>
+
+#include <nds/arm9/teak/dsp.h>
+
+void dspSetBlockReset(bool reset)
+{
+    REG_SCFG_RST = reset ? SCFG_RST_DSP_APPLY : SCFG_RST_DSP_RELEASE;
+}
+
+void dspSetClockEnabled(bool enabled)
+{
+    if (enabled)
+        REG_SCFG_CLK |= SCFG_CLK_DSP;
+    else
+        REG_SCFG_CLK &= ~SCFG_CLK_DSP;
+}
+
+void dspResetInterface()
+{
+    dspSpinWait();
+
+    if ((REG_DSP_PCFG & DSP_PCFG_RESET) == 0)
+        return;
+
+    REG_DSP_PCFG &= ~(DSP_PCFG_IE_REP0 | DSP_PCFG_IE_REP1 | DSP_PCFG_IE_REP2);
+    REG_DSP_PSEM = 0;
+    REG_DSP_PCLEAR = 0xFFFF;
+
+    // Clear reply registers
+    vu16 tmp = REG_DSP_REP0;
+    tmp = REG_DSP_REP1;
+    tmp = REG_DSP_REP2;
+    (void)tmp;
+}
+
+void dspSetCoreResetOn()
+{
+    dspSpinWait();
+
+    if (REG_DSP_PCFG & DSP_PCFG_RESET)
+        return;
+
+    REG_DSP_PCFG |= DSP_PCFG_RESET;
+    dspSpinWait();
+
+    while (REG_DSP_PSTS & DSP_PSTS_PERI_RESET);
+}
+
+void dspSetCoreResetOff(u16 repIrqMask)
+{
+    dspSpinWait();
+
+    while (REG_DSP_PSTS & DSP_PSTS_PERI_RESET);
+
+    dspResetInterface();
+    dspSpinWait();
+    REG_DSP_PCFG |= (repIrqMask & 7) << DSP_PCFG_IE_REP_SHIFT;
+    dspSpinWait();
+    REG_DSP_PCFG &= ~DSP_PCFG_RESET;
+}
+
+void dspPowerOn()
+{
+    REG_SCFG_EXT |= SCFG_EXT_DSP | SCFG_EXT_INTERRUPT;
+
+    dspSetBlockReset(true);
+    dspSetClockEnabled(true);
+    dspSpinWait();
+    dspSetBlockReset(false);
+    dspResetInterface();
+    dspSetCoreResetOn();
+}
+
+void dspPowerOff()
+{
+    REG_SCFG_EXT &= ~(SCFG_EXT_DSP | SCFG_EXT_INTERRUPT);
+
+    dspSetBlockReset(true);
+    dspSetClockEnabled(false);
+}
+
+void dspSendData(int id, u16 data)
+{
+    dspSpinWait();
+    while (REG_DSP_PSTS & (1 << (DSP_PSTS_CMD_UNREAD_SHIFT + id)));
+    (&REG_DSP_CMD0)[4 * id] = data;
+}
+
+bool dspSendDataReady(int id)
+{
+    dspSpinWait();
+    return (REG_DSP_PSTS & (1 << (DSP_PSTS_CMD_UNREAD_SHIFT + id))) == 0;
+}
+
+u16 dspReceiveData(int id)
+{
+    dspSpinWait();
+    while ((REG_DSP_PSTS & (1 << (DSP_PSTS_REP_NEW_SHIFT + id))) == 0);
+    return (&REG_DSP_REP0)[4 * id];
+}
+
+bool dspReceiveDataReady(int id)
+{
+    dspSpinWait();
+    return (REG_DSP_PSTS & (1 << (DSP_PSTS_REP_NEW_SHIFT + id))) ? true : false;
+}

--- a/source/arm9/teak/process.ctwl.c
+++ b/source/arm9/teak/process.ctwl.c
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+// Copyright (c) 2023 Antonio Niño Díaz
+
+#include <assert.h>
+#include <string.h>
+
+#include <nds/arm9/teak/dsp.h>
+#include <nds/arm9/teak/tlf.h>
+#include <nds/memory.h>
+#include <nds/nwram.h>
+
+static u16 _slotB;
+static u16 _slotC;
+static int _codeSegs;
+static int _dataSegs;
+static u8 _codeSlots[NWRAM_BC_SLOT_COUNT];
+static u8 _dataSlots[NWRAM_BC_SLOT_COUNT];
+
+static void *DspToArm9Address(bool isCodePtr, u32 addr)
+{
+    addr = DSP_MEM_ADDR_TO_CPU(addr);
+    int seg = addr >> NWRAM_BC_SLOT_SHIFT;
+    int offs = addr - (seg << NWRAM_BC_SLOT_SHIFT);
+    int slot = isCodePtr ? _codeSlots[seg] : _dataSlots[seg];
+    return (char *)nwramGetBlockAddress(isCodePtr ? NWRAM_BLOCK_B : NWRAM_BLOCK_C)
+            + slot * NWRAM_BC_SLOT_SIZE + offs;
+}
+
+static bool SetMemoryMapping(bool isCode, u32 addr, u32 len, bool toDsp)
+{
+    addr = DSP_MEM_ADDR_TO_CPU(addr);
+    len = DSP_MEM_ADDR_TO_CPU(len < 1 ? 1 : len);
+    int segBits = isCode ? _codeSegs : _dataSegs;
+    int start = addr >> NWRAM_BC_SLOT_SHIFT;
+    int end = (addr + len - 1) >> NWRAM_BC_SLOT_SHIFT;
+    for (int i = start; i <= end; i++)
+    {
+        if ((segBits & (1 << i)) == 0)
+            continue;
+        int slot = isCode ? _codeSlots[i] : _dataSlots[i];
+        if (isCode)
+        {
+            nwramMapWramBSlot(slot,
+                toDsp ? NWRAM_B_SLOT_MASTER_DSP_CODE : NWRAM_B_SLOT_MASTER_ARM9,
+                toDsp ? i : slot, true);
+        }
+        else
+        {
+            nwramMapWramCSlot(slot,
+                toDsp ? NWRAM_C_SLOT_MASTER_DSP_DATA : NWRAM_C_SLOT_MASTER_ARM9,
+                toDsp ? i : slot, true);
+        }
+    }
+
+    return true;
+}
+
+static bool Execute(void)
+{
+    dspPowerOn();
+    dspSetCoreResetOff(0);
+    dspSetSemaphoreMask(0);
+    return true;
+}
+
+bool dspExecuteTLF(const void *tlf)
+{
+    const tlf_header *header = tlf;
+
+    if (header->magic != TLF_MAGIC)
+        return false;
+
+    if (header->version != 0)
+        return false;
+
+    _slotB = 0xFF;
+    _slotC = 0xFF;
+
+    _codeSegs = 0xFF;
+    _dataSegs = 0xFF;
+
+    for (int i = 0; i < NWRAM_BC_SLOT_COUNT; i++)
+    {
+        _codeSlots[i] = i;
+        _dataSlots[i] = i;
+
+        nwramMapWramBSlot(i, NWRAM_B_SLOT_MASTER_ARM9, i, true);
+
+        u32 *slot = (u32 *)(nwramGetBlockAddress(NWRAM_BLOCK_B)
+                  + i * NWRAM_BC_SLOT_SIZE);
+
+        for (int j = 0; j < (NWRAM_BC_SLOT_SIZE >> 2); j++)
+            *slot++ = 0;
+
+        nwramMapWramCSlot(i, NWRAM_C_SLOT_MASTER_ARM9, i, true);
+
+        slot = (u32 *)(nwramGetBlockAddress(NWRAM_BLOCK_C)
+             + i * NWRAM_BC_SLOT_SIZE);
+
+        for (int j = 0; j < (NWRAM_BC_SLOT_SIZE >> 2); j++)
+            *slot++ = 0;
+    }
+
+    for (int i = 0; i < header->num_sections; i++)
+    {
+        const tlf_section_header *section = &(header->section[i]);
+        const void *data = ((const char *)tlf) + section->data_offset;
+        bool isCode = section->type == TLF_SEGMENT_CODE;
+        memcpy(DspToArm9Address(isCode, section->address), data, section->size);
+    }
+
+    SetMemoryMapping(true, 0,
+            (NWRAM_BC_SLOT_SIZE * NWRAM_BC_SLOT_COUNT) >> 1, true);
+    SetMemoryMapping(false, 0,
+            (NWRAM_BC_SLOT_SIZE * NWRAM_BC_SLOT_COUNT) >> 1, true);
+
+    return Execute();
+}

--- a/source/arm9/teak/utils.twl.s
+++ b/source/arm9/teak/utils.twl.s
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+// Copyright (C) 2023 Antonio Niño Díaz
+
+#include <nds/asminc.h>
+
+BEGIN_ASM_FUNC dspSpinWait itcm
+
+    // The jump to here took at least 3 cycles. The jump back took at least 3
+    // cycles as well. 2 nops should do.
+    nop
+    nop
+    bx lr

--- a/source/common/nwram.twl.c
+++ b/source/common/nwram.twl.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+// Copyright (c) 2023 Antonio Niño Díaz
+
+#include <stdint.h>
+
+#include <nds/nwram.h>
+#include <nds/memory.h>
+
+u32 nwramGetBlockAddress(NWRAM_BLOCK block)
+{
+    uint32_t start;
+
+    switch (block)
+    {
+        case NWRAM_BLOCK_A:
+            start = (REG_MBK6 & MBK6_START_ADDR_MASK) >> MBK6_START_ADDR_SHIFT;
+            return NWRAM_BASE + (start << NWRAM_A_SLOT_SHIFT);
+
+        case NWRAM_BLOCK_B:
+            start = (REG_MBK7 & MBK7_START_ADDR_MASK) >> MBK7_START_ADDR_SHIFT;
+            return NWRAM_BASE + (start << NWRAM_BC_SLOT_SHIFT);
+
+        case NWRAM_BLOCK_C:
+            start = (REG_MBK8 & MBK8_START_ADDR_MASK) >> MBK8_START_ADDR_SHIFT;
+            return NWRAM_BASE + (start << NWRAM_BC_SLOT_SHIFT);
+    }
+
+    return 0;
+}
+
+void nwramSetBlockMapping(NWRAM_BLOCK block, u32 start, u32 length,
+                          NWRAM_BLOCK_IMAGE_SIZE imageSize)
+{
+    start -= NWRAM_BASE;
+    u32 end;
+    switch (block)
+    {
+        case NWRAM_BLOCK_A:
+            start >>= NWRAM_A_SLOT_SHIFT;
+            length >>= NWRAM_A_SLOT_SHIFT;
+            end = start + length;
+            REG_MBK6 = (start << MBK6_START_ADDR_SHIFT)
+                     | (imageSize << MBK6_IMAGE_SIZE_SHIFT)
+                     | (end << MBK6_END_ADDR_SHIFT);
+            break;
+
+        case NWRAM_BLOCK_B:
+            start >>= NWRAM_BC_SLOT_SHIFT;
+            length >>= NWRAM_BC_SLOT_SHIFT;
+            end = start + length;
+            REG_MBK7 = (start << MBK7_START_ADDR_SHIFT)
+                     | (imageSize << MBK7_IMAGE_SIZE_SHIFT)
+                     | (end << MBK7_END_ADDR_SHIFT);
+            break;
+
+        case NWRAM_BLOCK_C:
+            start >>= NWRAM_BC_SLOT_SHIFT;
+            length >>= NWRAM_BC_SLOT_SHIFT;
+            end = start + length;
+            REG_MBK8 = (start << MBK8_START_ADDR_SHIFT)
+                     | (imageSize << MBK8_IMAGE_SIZE_SHIFT)
+                     | (end << MBK8_END_ADDR_SHIFT);
+            break;
+    }
+}
+
+#ifdef ARM9
+void nwramMapWramASlot(int slot, NWRAM_A_SLOT_MASTER master, int offset, bool enable)
+{
+    if (slot < 0 || slot > 3 || offset < 0 || offset > 3)
+        return;
+
+    REG_MBK1[slot] = enable ?
+        (NWRAM_A_SLOT_ENABLE | master | NWRAM_A_SLOT_OFFSET(offset)) : 0;
+}
+
+void nwramMapWramBSlot(int slot, NWRAM_B_SLOT_MASTER master, int offset, bool enable)
+{
+    if (slot < 0 || slot > 7 || offset < 0 || offset > 7)
+        return;
+
+    REG_MBK2[slot] = enable ?
+        (NWRAM_BC_SLOT_ENABLE | master | NWRAM_BC_SLOT_OFFSET(offset)) : 0;
+}
+
+void nwramMapWramCSlot(int slot, NWRAM_C_SLOT_MASTER master, int offset, bool enable)
+{
+    if (slot < 0 || slot > 7 || offset < 0 || offset > 7)
+        return;
+
+    REG_MBK4[slot] = enable ?
+        (NWRAM_BC_SLOT_ENABLE | master | NWRAM_BC_SLOT_OFFSET(offset)) : 0;
+}
+#endif // ARM9

--- a/source/teak/apbp.c
+++ b/source/teak/apbp.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+
+#include <teak/apbp.h>
+
+void apbpSendData(uint16_t id, uint16_t data)
+{
+    switch (id)
+    {
+        case 0:
+            while (REG_APBP_STAT & APBP_STAT_REP0_UNREAD);
+            REG_APBP_REP0 = data;
+            break;
+        case 1:
+            while (REG_APBP_STAT & APBP_STAT_REP1_UNREAD);
+            REG_APBP_REP1 = data;
+            break;
+        case 2:
+            while (REG_APBP_STAT & APBP_STAT_REP2_UNREAD);
+            REG_APBP_REP2 = data;
+            break;
+    }
+}
+
+uint16_t apbpReceiveData(uint16_t id)
+{
+    switch (id)
+    {
+        case 0:
+            while ((REG_APBP_STAT & APBP_STAT_CMD0_NEW) == 0);
+            return REG_APBP_CMD0;
+        case 1:
+            while ((REG_APBP_STAT & APBP_STAT_CMD1_NEW) == 0);
+            return REG_APBP_CMD1;
+        case 2:
+            while ((REG_APBP_STAT & APBP_STAT_CMD2_NEW) == 0);
+            return REG_APBP_CMD2;
+    }
+
+    return 0;
+}

--- a/source/teak/cpu_asm.s
+++ b/source/teak/cpu_asm.s
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+
+.text
+
+.global cpuDisableIrqs
+cpuDisableIrqs:
+    dint
+    ret always
+
+.global cpuEnableIrqs
+cpuEnableIrqs:
+    eint
+    ret always
+
+.global cpuDisableInt0
+cpuDisableInt0:
+    rst 0x100, mod3
+    ret always
+
+.global cpuEnableInt0
+cpuEnableInt0:
+    set 0x100, mod3
+    ret always
+
+.global cpuDisableInt1
+cpuDisableInt1:
+    rst 0x200, mod3
+    ret always
+
+.global cpuEnableInt1
+cpuEnableInt1:
+    set 0x200, mod3
+    ret always
+
+.global cpuDisableInt2
+cpuDisableInt2:
+    rst 0x400, mod3
+    ret always
+
+.global cpuEnableInt2
+cpuEnableInt2:
+    set 0x400, mod3
+    ret always
+
+.global cpuDisableVInt
+cpuDisableVInt:
+    rst 0x800, mod3
+    ret always
+
+.global cpuEnableVInt
+cpuEnableVInt:
+    set 0x800, mod3
+    ret always

--- a/source/teak/icu.c
+++ b/source/teak/icu.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2020 Gericom
+
+#include <teak/teak.h>
+
+void icuInit(void)
+{
+    cpuDisableIrqs();
+    REG_ICU_IRQ_DISABLE = 0xFFFF;
+    REG_ICU_IRQ_ACK = 0xFFFF;
+    REG_ICU_IRQ_INT0 = 0;
+    REG_ICU_IRQ_INT1 = 0;
+    REG_ICU_IRQ_INT2 = 0;
+    REG_ICU_IRQ_VINT = 0;
+    REG_ICU_IRQ_MODE = 0;
+    REG_ICU_IRQ_POLARITY = 0;
+    cpuDisableInt0();
+    cpuDisableInt1();
+    cpuDisableInt2();
+    cpuDisableVInt();
+    cpuEnableIrqs();
+}


### PR DESCRIPTION
libteak is a prototype library that can be used to develop binaries to be run in the DSP of the DSi. It requires ARM9 support, which is also added in this commit.