### PR TITLE
fatfs, nitrofs: properly populate st_dev and st_ino

### DIFF
--- a/source/arm9/libc/fatfs/ff.c
+++ b/source/arm9/libc/fatfs/ff.c
@@ -4799,6 +4799,11 @@ FRESULT f_stat (
 			/* BlocksDS - support origin directory stat(), write device/cluster information */
 			if (fno) {
 				fno->fpdrv = dj.obj.fs->pdrv;
+#if FF_FS_EXFAT
+				if (fs->fs_type == FS_EXFAT) {
+					fno->fclust = 0; /* FIXME */
+				} else
+#endif
 				fno->fclust = ld_clust(dj.obj.fs, dj.dir);
 				if (dj.fn[NSFLAG] & NS_NONAME) {	/* It is origin directory */
 					fno->fname[0] = 0;

--- a/source/arm9/libc/fatfs/ff.c
+++ b/source/arm9/libc/fatfs/ff.c
@@ -4796,8 +4796,10 @@ FRESULT f_stat (
 		INIT_NAMBUF(dj.obj.fs);
 		res = follow_path(&dj, path);	/* Follow the file path */
 		if (res == FR_OK) {				/* Follow completed */
-			/* BlocksDS - support origin directory stat() */
+			/* BlocksDS - support origin directory stat(), write device/cluster information */
 			if (fno) {
+				fno->fpdrv = dj.obj.fs->pdrv;
+				fno->fclust = ld_clust(dj.obj.fs, dj.dir);
 				if (dj.fn[NSFLAG] & NS_NONAME) {	/* It is origin directory */
 					fno->fname[0] = 0;
 #ifdef FF_USE_LFN

--- a/source/arm9/libc/fatfs/ff.h
+++ b/source/arm9/libc/fatfs/ff.h
@@ -247,12 +247,14 @@ typedef struct {
 	WORD	fdate;			/* Modified date */
 	WORD	ftime;			/* Modified time */
 	BYTE	fattrib;		/* File attribute */
+	BYTE    fpdrv;          /* BlocksDS: Physical drive ID. */
 #if FF_USE_LFN
 	TCHAR	altname[FF_SFN_BUF + 1];/* Alternative file name */
 	TCHAR	fname[FF_LFN_BUF + 1];	/* Primary file name */
 #else
 	TCHAR	fname[12 + 1];	/* File name */
 #endif
+	DWORD   fclust;         /* BlocksDS: File cluster. */
 } FILINFO;
 
 

--- a/source/arm9/libc/filesystem.c
+++ b/source/arm9/libc/filesystem.c
@@ -283,6 +283,8 @@ int stat(const char *path, struct stat *st)
         return -1;
     }
 
+    st->st_dev = fno.fpdrv;
+    st->st_ino = fno.fclust;
     st->st_size = fno.fsize;
 
 #if FF_MAX_SS != FF_MIN_SS
@@ -328,6 +330,8 @@ int fstat(int fd, struct stat *st)
 
     FIL *fp = (FIL *)fd;
 
+    st->st_dev = fp->obj.fs->pdrv;
+    st->st_ino = fp->obj.sclust;
     st->st_size = fp->obj.objsize;
 
 #if FF_MAX_SS != FF_MIN_SS

--- a/source/arm9/libc/filesystem.c
+++ b/source/arm9/libc/filesystem.c
@@ -283,8 +283,11 @@ int stat(const char *path, struct stat *st)
         return -1;
     }
 
+    // On FatFS, st_dev is either 0 (DLDI) or 1 (DSi SD),
+    // while st_ino is the file's starting cluster in FAT.
     st->st_dev = fno.fpdrv;
     st->st_ino = fno.fclust;
+
     st->st_size = fno.fsize;
 
 #if FF_MAX_SS != FF_MIN_SS
@@ -330,6 +333,8 @@ int fstat(int fd, struct stat *st)
 
     FIL *fp = (FIL *)fd;
 
+    // On FatFS, st_dev is either 0 (DLDI) or 1 (DSi SD),
+    // while st_ino is the file's starting cluster in FAT.
     st->st_dev = fp->obj.fs->pdrv;
     st->st_ino = fp->obj.sclust;
     st->st_size = fp->obj.objsize;

--- a/source/arm9/libc/nitrofs.c
+++ b/source/arm9/libc/nitrofs.c
@@ -431,6 +431,7 @@ int nitrofs_open(const char *name)
 
 static int nitrofs_stat_file_internal(nitrofs_file_t *fp, struct stat *st)
 {
+    st->st_dev = 2;
     st->st_ino = fp->file_index;
     st->st_size = fp->endofs - fp->offset;
     st->st_blksize = 0x200;

--- a/source/arm9/libc/nitrofs.c
+++ b/source/arm9/libc/nitrofs.c
@@ -431,6 +431,7 @@ int nitrofs_open(const char *name)
 
 static int nitrofs_stat_file_internal(nitrofs_file_t *fp, struct stat *st)
 {
+    // On NitroFS, st_dev is always 2, while st_ino is the file's unique ID.
     st->st_dev = 2;
     st->st_ino = fp->file_index;
     st->st_size = fp->endofs - fp->offset;


### PR DESCRIPTION
As per [POSIX specifications](https://pubs.opengroup.org/onlinepubs/009695299/basedefs/sys/stat.h.html), 

>The st_ino and st_dev fields taken together uniquely identify the file within the system.

This PR implements that for FAT and NitroFS filesystems as such:

* For FAT filesystems, `st_dev` is 0 (DLDI) or 1 (DSi SD), while `st_ino` is the starting cluster of the file;
* For NitroFS filesystems, `st_dev` is 2, while `st_ino` is the unique ID of the file within the `.nds` file.

I believe it to be unwise to document the exact meaning of these values outside of code, as users should not rely on them.

Whether this should be merged or not, I'm not too sure; it *does* resolve https://github.com/blocksds/sdk/issues/85 , but I don't think code should be relying on this... But here it is, anyway.