### PR TITLE
sound, timers: round frequencies to nearest, fix documentation

### DIFF
--- a/include/nds/arm7/audio.h
+++ b/include/nds/arm7/audio.h
@@ -28,7 +28,7 @@ extern "C" {
 #include <nds/timers.h>
 
 #define SOUND_VOL(n)        (n)
-#define SOUND_FREQ(n)       TIMER_FREQ_SHIFT(n, 1)
+#define SOUND_FREQ(n)       TIMER_FREQ_SHIFT(n, 1, 1)
 #define SOUND_ENABLE        BIT(15)
 
 #define SOUND_REPEAT        BIT(27)

--- a/include/nds/arm7/audio.h
+++ b/include/nds/arm7/audio.h
@@ -25,9 +25,10 @@ extern "C" {
 
 #include <nds/arm7/serial.h>
 #include <nds/system.h>
+#include <nds/timers.h>
 
 #define SOUND_VOL(n)        (n)
-#define SOUND_FREQ(n)       ((-0x1000000 / (n)))
+#define SOUND_FREQ(n)       TIMER_FREQ_SHIFT(n, 1)
 #define SOUND_ENABLE        BIT(15)
 
 #define SOUND_REPEAT        BIT(27)

--- a/include/nds/timers.h
+++ b/include/nds/timers.h
@@ -117,7 +117,7 @@ typedef enum {
 /// - ClockDivider_256  = 8
 /// - ClockDivider_1024 = 10
 /// - ARM7 sound timer  = 1
-#define TIMER_FREQ_SHIFT(n, shift) (-((BUS_CLOCK >> (shift)) + (((n - 1)) >> 1)) / (n))
+#define TIMER_FREQ_SHIFT(n, divisor, shift) ((-((BUS_CLOCK >> (shift)) * (divisor)) - ((((n) + 1)) >> 1)) / (n))
 
 /// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
@@ -134,7 +134,7 @@ typedef enum {
 /// Min frequency is: ~511 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ(n)    TIMER_FREQ_SHIFT(n, 0)
+#define TIMER_FREQ(n)    TIMER_FREQ_SHIFT(n, 1, 0)
 
 /// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
@@ -151,7 +151,7 @@ typedef enum {
 /// Min frequency is: 8 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ_64(n) TIMER_FREQ_SHIFT(n, 6)
+#define TIMER_FREQ_64(n) TIMER_FREQ_SHIFT(n, 1, 6)
 
 /// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
@@ -168,7 +168,7 @@ typedef enum {
 /// Min frequency is: ~2 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ_256(n) TIMER_FREQ_SHIFT(n, 8)
+#define TIMER_FREQ_256(n) TIMER_FREQ_SHIFT(n, 1, 8)
 
 /// Macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
@@ -185,7 +185,7 @@ typedef enum {
 /// Min frequency is: ~0.5 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ_1024(n) TIMER_FREQ_SHIFT(n, 10)
+#define TIMER_FREQ_1024(n) TIMER_FREQ_SHIFT(n, 1, 10)
 
 /// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
@@ -199,7 +199,7 @@ typedef enum {
 /// Min frequency is: ~512 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ_SOUND(n) (TIMER_FREQ_SHIFT(n, 1) << 1)
+#define TIMER_FREQ_SOUND(n) (TIMER_FREQ_SHIFT(n, 1, 1) << 1)
 
 /// Start a hardware timer.
 ///

--- a/include/nds/timers.h
+++ b/include/nds/timers.h
@@ -108,6 +108,17 @@ typedef enum {
 /// Causes the timer to count at (33.514 / 1024) MHz.
 #define TIMER_DIV_1024  (3)
 
+/// A macro that calculates TIMER_DATA(n) settings for a given frequency of n
+/// and shift. Correctly rounds the timer to the closest available frequency.
+///
+/// Shift values:
+/// - ClockDivider_1    = 0
+/// - ClockDivider_64   = 6
+/// - ClockDivider_256  = 8
+/// - ClockDivider_1024 = 10
+/// - ARM7 sound timer  = 1
+#define TIMER_FREQ_SHIFT(n, shift) (-((BUS_CLOCK >> (shift)) + (((n - 1)) >> 1)) / (n))
+
 /// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
 /// It will calculate the correct value for TIMER_DATA(n) given the frequency
@@ -123,7 +134,7 @@ typedef enum {
 /// Min frequency is: 512 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ(n)    (-BUS_CLOCK / (n))
+#define TIMER_FREQ(n)    TIMER_FREQ_SHIFT(n, 0)
 
 /// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
@@ -140,7 +151,7 @@ typedef enum {
 /// Min frequency is: 8 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ_64(n) (-(BUS_CLOCK >> 6) / (n))
+#define TIMER_FREQ_64(n) TIMER_FREQ_SHIFT(n, 6)
 
 /// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
@@ -157,7 +168,7 @@ typedef enum {
 /// Min frequency is: 2 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ_256(n) (-(BUS_CLOCK >> 8) / (n))
+#define TIMER_FREQ_256(n) TIMER_FREQ_SHIFT(n, 8)
 
 /// Macro that calculates TIMER_DATA(n) settings for a given frequency of n.
 ///
@@ -174,7 +185,7 @@ typedef enum {
 /// Min frequency is: 0.5 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ_1024(n) (-(BUS_CLOCK >> 10) / (n))
+#define TIMER_FREQ_1024(n) TIMER_FREQ_SHIFT(n, 10)
 
 /// Start a hardware timer.
 ///

--- a/include/nds/timers.h
+++ b/include/nds/timers.h
@@ -126,12 +126,12 @@ typedef enum {
 ///
 /// **Example Usage:**
 /// ```
-/// // Calls the timerCallBack function 5 times per second.
-/// timerStart(0, ClockDivider_1024, TIMER_FREQ_1024(5), timerCallBack);
+/// // Calls the timerCallBack function 5000 times per second.
+/// timerStart(0, ClockDivider_1, TIMER_FREQ(5000), timerCallBack);
 /// ```
 ///
-/// Max frequency is: 33554432 Hz
-/// Min frequency is: 512 Hz
+/// Max frequency is: 33513982 Hz
+/// Min frequency is: ~511 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
 #define TIMER_FREQ(n)    TIMER_FREQ_SHIFT(n, 0)
@@ -143,11 +143,11 @@ typedef enum {
 ///
 /// **Example Usage:**
 /// ```
-/// // Calls the timerCallBack function 5 times per second.
-/// timerStart(0, ClockDivider_1024, TIMER_FREQ_1024(5), timerCallBack);
+/// // Calls the timerCallBack function 500 times per second.
+/// timerStart(0, ClockDivider_64, TIMER_FREQ_64(500), timerCallBack);
 /// ```
 ///
-/// Max frequency is: 524288 Hz
+/// Max frequency is: ~523656 Hz
 /// Min frequency is: 8 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
@@ -160,12 +160,12 @@ typedef enum {
 ///
 /// **Example Usage:**
 /// ```
-/// // Calls the timerCallBack function 5 times per second.
-/// timerStart(0, ClockDivider_1024, TIMER_FREQ_1024(5), timerCallBack);
+/// // Calls the timerCallBack function 50 times per second.
+/// timerStart(0, ClockDivider_256, TIMER_FREQ_256(50), timerCallBack);
 /// ```
 ///
-/// Max frequency is: 131072 Hz
-/// Min frequency is: 2 Hz
+/// Max frequency is: ~130914 Hz
+/// Min frequency is: ~2 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
 #define TIMER_FREQ_256(n) TIMER_FREQ_SHIFT(n, 8)
@@ -181,11 +181,25 @@ typedef enum {
 /// timerStart(0, ClockDivider_1024, TIMER_FREQ_1024(5), timerCallBack);
 /// ```
 ///
-/// Max frequency is: 32768 Hz
-/// Min frequency is: 0.5 Hz
+/// Max frequency is: ~32728 Hz
+/// Min frequency is: ~0.5 Hz
 ///
 /// @note Use the appropriate macro depending on the used clock divider.
 #define TIMER_FREQ_1024(n) TIMER_FREQ_SHIFT(n, 10)
+
+/// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
+///
+/// It will calculate the correct value for TIMER_DATA(n) given the frequency
+/// in Hz (number of times the timer should overflow per second).
+///
+/// This macro works like TIMER_FREQ(n), except it emits values which will
+/// be synchronized to the frequency of SOUND_FREQ(n) for any given n.
+///
+/// Max frequency is: 16756991 Hz
+/// Min frequency is: ~512 Hz
+///
+/// @note Use the appropriate macro depending on the used clock divider.
+#define TIMER_FREQ_SOUND(n) (TIMER_FREQ_SHIFT(n, 1) << 1)
 
 /// Start a hardware timer.
 ///

--- a/include/nds/timers.h
+++ b/include/nds/timers.h
@@ -187,20 +187,6 @@ typedef enum {
 /// @note Use the appropriate macro depending on the used clock divider.
 #define TIMER_FREQ_1024(n) TIMER_FREQ_SHIFT(n, 1, 10)
 
-/// A macro that calculates TIMER_DATA(n) settings for a given frequency of n.
-///
-/// It will calculate the correct value for TIMER_DATA(n) given the frequency
-/// in Hz (number of times the timer should overflow per second).
-///
-/// This macro works like TIMER_FREQ(n), except it emits values which will
-/// be synchronized to the frequency of SOUND_FREQ(n) for any given n.
-///
-/// Max frequency is: 16756991 Hz
-/// Min frequency is: ~512 Hz
-///
-/// @note Use the appropriate macro depending on the used clock divider.
-#define TIMER_FREQ_SOUND(n) (TIMER_FREQ_SHIFT(n, 1, 1) << 1)
-
 /// Start a hardware timer.
 ///
 /// Callback is tied directly to interrupt table and called directly, resulting


### PR DESCRIPTION
… frequency

This is an attempt at resolving https://github.com/blocksds/sdk/issues/42 - of course, some testing would be required. `libxm7` works fine, so the `SOUND_FREQ` values are sound - but this also impacts `TIMER_FREQ`, and possibly code size/performance. Would be good to look for some homebrew that make heavy use of those.

~~Two changes are made, currently:

* ~~Synchronize `TIMER_FREQ` and `SOUND_FREQ` definitions with each other, so that the same frequency leads to the same speed in both cases.~~
* Make both defintions round to the nearest frequency, instead of rounding up.

Some things to consider:

* Is rounding to nearest, that is *including rounding down*, for timers acceptable in the first place? It's good for sampled audio, but what about other usecases?
* ~~`TIMER_FREQ` has 2x the precision of `SOUND_FREQ`; combined with the above question, I'd consider adding a `TIMER_SOUND_FREQ` which ensures that the speed of `TIMER_SOUND_FREQ(n)` == `SOUND_FREQ(n)` for any `n`.~~ Not in this PR.