### PR TITLE
firmware: add readJEDEC()

### DIFF
--- a/include/nds/arm7/serial.h
+++ b/include/nds/arm7/serial.h
@@ -93,6 +93,9 @@ static inline void SerialWaitBusy(void)
 // Read the firmware
 void readFirmware(u32 address, void *destination, u32 size);
 
+// Read internal flash JEDEC values
+int readJEDEC(u8 *destination, u32 size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/arm7/firmware.c
+++ b/source/arm7/firmware.c
@@ -39,6 +39,24 @@ void readFirmware(u32 address, void *destination, u32 size)
     leaveCriticalSection(oldIME);
 }
 
+int readJEDEC(u8 *destination, u32 size) {
+    if (destination == NULL)
+        return -1;
+
+    // JEDEC is always 3 bytes.
+    if (size < 3)
+        return -2;
+
+    int oldIME = enterCriticalSection();
+    REG_SPICNT = SPI_ENABLE | SPI_BYTE_MODE | SPI_CONTINUOUS | SPI_DEVICE_FIRMWARE;
+    readwriteSPI(FIRMWARE_RDID); // get JEDEC
+    for (int i = 0; i < 3; i++) {
+        destination[i] = readwriteSPI(0);
+    }
+    REG_SPICNT = 0;
+    leaveCriticalSection(oldIME);
+}
+
 static int writeFirmwarePage(u32 address, u8 *buffer)
 {
     u8 pagebuffer[256];


### PR DESCRIPTION
This is a helper function to read the flash JEDEC values.

A use case for this function is to retrieve the size of the flash; this can be useful in verifying internal hardware, or verify the size of the flash before doing a read of the entire device.