### PR TITLE
nitrofs: fix missing fclose() if pointed to NitroFS-less .nds file

### DIFF
--- a/source/arm9/libc/nitrofs.c
+++ b/source/arm9/libc/nitrofs.c
@@ -539,10 +539,17 @@ bool nitroFSInit(const char *basepath)
     {
         memcpy(nitrofs_offsets, &(__NDSHeader->filenameOffset), 4 * sizeof(uint32_t));
 
-        // If not reading from DLDI, we could still be reading from Slot-2.
-        // Figure this out by comparing NitroFS header data between the two.
-        sysSetCartOwner(BUS_OWNER_ARM9);
-        nitrofs_local.use_slot2 = !memcmp(((uint16_t*) 0x08000040), nitrofs_offsets, 4 * sizeof(uint32_t));
+        if (!isDSiMode())
+        {
+            // If not reading from DLDI, we could still be reading from Slot-2.
+            // Figure this out by comparing NitroFS header data between the two.
+            sysSetCartOwner(BUS_OWNER_ARM9);
+            nitrofs_local.use_slot2 = !memcmp(((uint16_t*) 0x08000040), nitrofs_offsets, 4 * sizeof(uint32_t));
+        }
+        else
+        {
+            nitrofs_local.use_slot2 = false;
+        }
     }
 
     if (!(nitrofs_offsets[0] >= 0x200 && nitrofs_offsets[1] > 0 && nitrofs_offsets[2] >= 0x200 && nitrofs_offsets[3] > 0))

--- a/source/arm9/libc/nitrofs.c
+++ b/source/arm9/libc/nitrofs.c
@@ -546,7 +546,11 @@ bool nitroFSInit(const char *basepath)
     }
 
     if (!(nitrofs_offsets[0] >= 0x200 && nitrofs_offsets[1] > 0 && nitrofs_offsets[2] >= 0x200 && nitrofs_offsets[3] > 0))
+    {
+        if (nitrofs_local.file)
+            fclose(nitrofs_local.file);
         return false;
+    }
     nitrofs_local.fnt_offset = nitrofs_offsets[0];
     nitrofs_local.fat_offset = nitrofs_offsets[2];
 


### PR DESCRIPTION
This is unlikely to be hit in production, and so doesn't warrant an 0.10.3.