### PR TITLE
fatfs: Support batching contiguous cluster reads.

### DIFF
--- a/source/arm9/libc/fatfs/ff.c
+++ b/source/arm9/libc/fatfs/ff.c
@@ -3969,7 +3969,7 @@ FRESULT f_read (
 					prevclst = nextclst;
 #if FF_USE_FASTSEEK
 					if (fp->cltbl) {
-						nextclst = clmt_clust(fp, fp->fptr + contiguous_cluster_size);	/* Get cluster# from the CLMT */
+						nextclst = clmt_clust(fp, fp->fptr + (contiguous_cluster_size * SS(fs)));	/* Get cluster# from the CLMT */
 					} else
 #endif
 					{
@@ -4103,7 +4103,7 @@ FRESULT f_write (
 					prevclst = nextclst;
 #if FF_USE_FASTSEEK
 					if (fp->cltbl) {
-						nextclst = clmt_clust(fp, fp->fptr + contiguous_cluster_size);	/* Get cluster# from the CLMT */
+						nextclst = clmt_clust(fp, fp->fptr + (contiguous_cluster_size * SS(fs)));	/* Get cluster# from the CLMT */
 					} else
 #endif
 					{


### PR DESCRIPTION
This allows reading in units larger than one cluster (4KB on smaller cards, up to 32KB if the user manually requests it). For the 4KB case, this gets read speed up from 5.9 MB/s to 7.3 MB/s on my tests with the experimental picolibc patches. 7.3 MB/s is close to the DSi's theoretical bus speed, and likely to be very close to the practical TMIO speed limit; there's also latency overhead of the libc/FatFS stack, as well as latency overhead of the SD card itself, to take into account.