### PR TITLE
fatfs: add fatInitLookupCache() to expose FF_USE_FASTSEEK

### DIFF
--- a/include/fat.h
+++ b/include/fat.h
@@ -15,6 +15,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 /// This function calls fatInit() with the default cache size (5 pages = 20 KB).
 ///
@@ -61,6 +62,30 @@ bool fatInit(uint32_t cache_size_pages, bool set_as_default_device);
 ///
 /// @return Returns a string with the path.
 char *fatGetDefaultCwd(void);
+
+/// This function initializes a lookup cache on a given FAT file.
+/// For NitroFS, use @see nitrofsInitLookupCache instead.
+///
+/// This lookup cache allows avoiding expensive SD card lookups for large and/or
+/// backwards lookups, at the expensive of RAM usage.
+///
+/// Note that, if the file is opened for writing, using this function will
+/// prevent the file's size from being expanded.
+///
+/// @param fd The file descriptor to initialize. Use fileno(file) for FILE *
+///           inputs.
+/// @param max_buffer_size The maximum buffer size, in bytes.
+///
+/// @return 0 if the initialization was successful, a non-zero value on error.
+int fatInitLookupCache(int fd, uint32_t max_buffer_size);
+
+static inline int fatInitLookupCacheFile(FILE *file, uint32_t max_buffer_size) {
+    return fatInitLookupCache(fileno(file), max_buffer_size);
+}
+
+#define FAT_INIT_LOOKUP_CACHE_NOT_SUPPORTED     -1
+#define FAT_INIT_LOOKUP_CACHE_OUT_OF_MEMORY     -2
+#define FAT_INIT_LOOKUP_CACHE_ALREADY_ALLOCATED -3
 
 #ifdef __cplusplus
 }

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -14,6 +14,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /// Initializes NitroFS.
 ///
@@ -27,6 +28,19 @@ bool nitroFSInit(const char *basepath);
 
 /// Exits NitroFS.
 void nitroFSExit(void);
+
+/// This function initializes a NitroFS lookup cache.
+///
+/// This lookup cache allows avoiding expensive SD card lookups for large
+/// and/or backwards seeks, at the expensive of RAM usage.
+///
+/// This function will return 0 on non-DLDI/SD NitroFS accesses, as lookup
+/// caches are unnecessary in these situations.
+///
+/// @param max_buffer_size The maximum buffer size, in bytes.
+///
+/// @return 0 if the initialization was successful, a non-zero value on error.
+int nitroFSInitLookupCache(uint32_t max_buffer_size);
 
 #ifdef __cplusplus
 }

--- a/source/arm9/libc/fatfs/ffconf.h
+++ b/source/arm9/libc/fatfs/ffconf.h
@@ -50,7 +50,7 @@
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
 
-#define FF_USE_FASTSEEK	0
+#define FF_USE_FASTSEEK	1
 /* This option switches fast seek function. (0:Disable or 1:Enable) */
 
 

--- a/source/arm9/libc/filesystem.c
+++ b/source/arm9/libc/filesystem.c
@@ -191,6 +191,8 @@ int close(int fd)
 
     FRESULT result = f_close(fp);
 
+    if (fp->cltbl != NULL)
+        free(fp->cltbl);
     free(fp);
 
     if (result == FR_OK)

--- a/source/arm9/libc/nitrofs.c
+++ b/source/arm9/libc/nitrofs.c
@@ -568,3 +568,9 @@ bool nitroFSInit(const char *basepath)
 
     return true;
 }
+
+int nitroFSInitLookupCache(uint32_t max_buffer_size) {
+    if (!nitrofs_initialized || !nitrofs_local.file)
+        return 0;
+    return fatInitLookupCacheFile(nitrofs_local.file, max_buffer_size);
+}


### PR DESCRIPTION
This adds a *significant* speed boost to random accesses; as FAT clusters are stored as an unpacked linked list (so one linked list jump per 4KB cluster), seeking, especially backwards, takes a very long time for larger files. We mitigate this somewhat with the sector cache, but this is a proper fix.

FF_USE_FASTSEEK (exposed via `fatInitLookupCache()`) creates a packed (one linked list jump per non-contiguous cluster) linked list as a cache, making seeks *much* cheaper (no filesystem call, much smaller table to traverse).

After discussing with Gericom, it appears that even for large files, so long as they are lightly/not fragmented, the FASTSEEK buffer size can be measured in the hundreds of bytes. In addition, NitroFS accesses often rely on large backwards/forwards seeks across the file (for the FNT/FAT tables). As such, I will be combining this PR with the work in https://github.com/blocksds/libnds/pull/59 for a future PR as follows:

* `fatInitSectorCache()` will be separated out of `fatInit()`, allowing the initialization (and resizing) of the sector cache dynamically.
* If `nitroFSInit()` is called, and `fatInit()` was *not* called previously, it will reserve some of the DLDI driver space for the NitroFS seek lookup cache. This should be minimal (hundreds of bytes; maybe a few kilobytes on a highly fragmented card); if the lookup cache is too large, it will simply not be initialized. In addition, the FAT sector cache would be fully unused by a program that loads all assets from in NitroFS, so this trade-off makes sense IMO.
* If an user wants full manual control, they can still call `fatInit()` first, then `nitroFSInit()`, then enable the NitroFS lookup cache separately.

Yes, it's a little complicated, but this will give the fastest possible behaviour for both FAT-only and FAT+NitroFS users, while still allowing a high degree of control over what goes where.