### PR TITLE
ndsabi: fix memcpy/memset regression

### DIFF
--- a/include/nds/asminc.h
+++ b/include/nds/asminc.h
@@ -18,6 +18,13 @@
 \name:
 .endm
 
+.macro BEGIN_ASM_FUNC_NO_SECTION name
+    .global \name
+    .type \name, %function
+    .align 2
+\name:
+.endm
+
 #define ICACHE_SIZE     0x2000
 #define DCACHE_SIZE     0x1000
 #define CACHE_LINE_SIZE 32

--- a/source/common/ndsabi/memcpy.s
+++ b/source/common/ndsabi/memcpy.s
@@ -45,8 +45,8 @@ BEGIN_ASM_FUNC __aeabi_memcpy
     @ r0, r1 are now word aligned
 
 
-BEGIN_ASM_FUNC __aeabi_memcpy8
-BEGIN_ASM_FUNC __aeabi_memcpy4
+BEGIN_ASM_FUNC_NO_SECTION __aeabi_memcpy8
+BEGIN_ASM_FUNC_NO_SECTION __aeabi_memcpy4
 
     cmp     r2, #32
     blt     .Lcopy_words
@@ -94,7 +94,7 @@ BEGIN_ASM_FUNC __aeabi_memcpy4
     @ r0, r1 are now half aligned
 
 
-BEGIN_ASM_FUNC __ndsabi_memcpy2
+BEGIN_ASM_FUNC_NO_SECTION __ndsabi_memcpy2
 
     subs    r2, r2, #2
     ldrhge  r3, [r1], #2
@@ -109,7 +109,7 @@ BEGIN_ASM_FUNC __ndsabi_memcpy2
     bx      lr
 
 
-BEGIN_ASM_FUNC __ndsabi_memcpy1
+BEGIN_ASM_FUNC_NO_SECTION __ndsabi_memcpy1
 
     subs    r2, r2, #1
     ldrbge  r3, [r1], #1

--- a/source/common/ndsabi/memset.s
+++ b/source/common/ndsabi/memset.s
@@ -49,20 +49,20 @@ BEGIN_ASM_FUNC __aeabi_memset
     subcs   r1, r1, #2
 
 
-BEGIN_ASM_FUNC __aeabi_memset8
-BEGIN_ASM_FUNC __aeabi_memset4
+BEGIN_ASM_FUNC_NO_SECTION __aeabi_memset8
+BEGIN_ASM_FUNC_NO_SECTION __aeabi_memset4
 
     lsl     r2, r2, #24
     orr     r2, r2, r2, lsr #8
     orr     r2, r2, r2, lsr #16
 
 
-BEGIN_ASM_FUNC __ndsabi_wordset4
+BEGIN_ASM_FUNC_NO_SECTION __ndsabi_wordset4
 
     mov     r3, r2
 
 
-BEGIN_ASM_FUNC __ndsabi_lwordset4
+BEGIN_ASM_FUNC_NO_SECTION __ndsabi_lwordset4
 
     @ 16 words is roughly the threshold when lwordset is slower
     cmp     r1, #64


### PR DESCRIPTION
Regressed in https://github.com/blocksds/libnds/commit/634499db828284a5c372d38cda05946b245a90b2

Not every function can live in a distinct section. In some cases, there's a deliberate fallthrough - this fixes the issue.