### PR TITLE
camera: Wrap functions to prevent crash in NDS mode

### DIFF
--- a/include/nds/arm9/camera.h
+++ b/include/nds/arm9/camera.h
@@ -67,10 +67,10 @@ static inline bool cameraTransferActive(void)
 }
 
 // Low-level I2C/MCU functions
-u16 cameraI2cRead(u8 device, u16 reg);
-u16 cameraI2cWrite(u8 device, u16 reg, u16 value);
-u16 cameraMcuRead(u8 device, u16 reg);
-u16 cameraMcuWrite(u8 device, u16 reg, u16 value);
+u16 cameraI2cReadTWL(u8 device, u16 reg);
+u16 cameraI2cWriteTWL(u8 device, u16 reg, u16 value);
+u16 cameraMcuReadTWL(u8 device, u16 reg);
+u16 cameraMcuWriteTWL(u8 device, u16 reg, u16 value);
 
 #ifdef __cplusplus
 }

--- a/source/arm9/peripherals/camera.c
+++ b/source/arm9/peripherals/camera.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2023 Adrian "asie" Siekierka
+
+// Camera control for the ARM9
+
+#include <stdio.h>
+
+#include <nds.h>
+#include <nds/fifomessages.h>
+
+// High-level functions
+
+u8 cameraActiveDevice = CAMERA_NONE;
+
+u8 cameraGetActive(void)
+{
+    return cameraActiveDevice;
+}
+
+extern bool cameraInitTWL(void);
+bool cameraInit(void)
+{
+    if (!isDSiMode())
+        return false;
+    return cameraInitTWL();
+}
+
+extern bool cameraDeinitTWL(void);
+bool cameraDeinit(void)
+{
+    if (!isDSiMode())
+        return false;
+    return cameraDeinitTWL();
+}
+
+extern bool cameraSelectTWL(CameraDevice device);
+bool cameraSelect(CameraDevice device)
+{
+    if (!isDSiMode())
+        return false;
+    return cameraSelectTWL(device);
+}
+
+extern bool cameraStartTransferTWL(u16 *buffer, u8 captureMode, u8 ndmaId);
+bool cameraStartTransfer(u16 *buffer, u8 captureMode, u8 ndmaId)
+{
+    if (!isDSiMode())
+        return false;
+    return cameraStartTransferTWL(buffer, captureMode, ndmaId);
+}


### PR DESCRIPTION
No worries, does not justify a new release - but it does match existing libnds behaviour to check for this.