### PR TITLE
cache, interrupts, types: link-time optimization fixes

### DIFF
--- a/include/nds/ndstypes.h
+++ b/include/nds/ndstypes.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <stdint.h>
 
 /// Used to place a function in ITCM
-#define ITCM_CODE __attribute__((section(".itcm"), long_call))
+#define ITCM_CODE __attribute__((section(".itcm.text"), long_call))
 
 /// Used to place initialized data in DTCM
 #define DTCM_DATA __attribute__((section(".dtcm")))
@@ -32,9 +32,9 @@ extern "C" {
 #define DTCM_BSS __attribute__((section(".sbss")))
 
 /// Used to place a function in DSi RAM.
-#define TWL_CODE __attribute__((section(".twl")))
+#define TWL_CODE __attribute__((section(".twl.text")))
 /// Used to place initialized data in DSi RAM.
-#define TWL_DATA __attribute__((section(".twl")))
+#define TWL_DATA __attribute__((section(".twl.data")))
 /// Used to place uninitialized data in DSi RAM.
 #define TWL_BSS __attribute__((section(".twl_bss")))
 

--- a/source/arm9/system/cache.c
+++ b/source/arm9/system/cache.c
@@ -23,7 +23,7 @@ uintptr_t align_down(const void *address, size_t size)
 // - Align start to the cache line size, rounded down to include the base.
 // - Align end to the cache line size too, but round up to include the end.
 
-ITCM_CODE ARM_CODE
+ITCM_CODE ARM_CODE __attribute__((noinline))
 void CP15_CleanAndFlushDCacheRange(const void *base, size_t size)
 {
     uintptr_t address = align_down(base, CACHE_LINE_SIZE);
@@ -40,7 +40,7 @@ void CP15_CleanAndFlushDCacheRange(const void *base, size_t size)
                  "mcr p15, 0, r0, c7, c10, 4" ::: "r0", "memory");
 }
 
-ITCM_CODE ARM_CODE
+ITCM_CODE ARM_CODE __attribute__((noinline))
 void CP15_FlushDCacheRange(const void *base, size_t size)
 {
     uintptr_t address = align_down(base, CACHE_LINE_SIZE);
@@ -53,7 +53,7 @@ void CP15_FlushDCacheRange(const void *base, size_t size)
     // There is nothing to write to memory.
 }
 
-ITCM_CODE ARM_CODE
+ITCM_CODE ARM_CODE __attribute__((noinline))
 void CP15_FlushICacheRange(const void *base, size_t size)
 {
     uintptr_t address = align_down(base, CACHE_LINE_SIZE);

--- a/source/common/interrupts.c
+++ b/source/common/interrupts.c
@@ -18,7 +18,7 @@ void irqDummy(void)
 }
 
 #ifdef ARM9
-#define INT_TABLE_SECTION __attribute__((section(".itcm")))
+#define INT_TABLE_SECTION __attribute__((section(".itcm.data")))
 #else
 #define INT_TABLE_SECTION
 #endif


### PR DESCRIPTION
* Place code and data in distinct sections. They receive different section flags, which can be handled by the GNU linker, but not by GCC itself - so for the annotations to work properly for LTO code (even if libnds itself is not compiled using LTO), they must name distinct sections.
* Add `__attribute__((noinline))` to functions which use assembly specific to ARM mode - otherwise, attempting to inline them across translations units into Thumb code will cause a compile error.