### PR TITLE
filesystem: general improvements

### DIFF
--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -42,6 +42,33 @@ void nitroFSExit(void);
 /// @return 0 if the initialization was successful, a non-zero value on error.
 int nitroFSInitLookupCache(uint32_t max_buffer_size);
 
+/// Open a NitroFS file descriptor directly by its FAT offset ID.
+///
+/// This FAT offset ID can be sourced from functions like @see stat,
+/// @see fstat or @see readdir - it is equivalent to the st_ino/d_ino value.
+///
+/// In all other functions, this file descriptor behaves identically to one
+/// sourced from @see open , and should be closed likewise.
+///
+/// @param id The FAT offset ID of the file (0x0000..0xEFFF).
+///
+/// @return A valid file descriptor; -1 on error.
+int nitroFSOpenById(uint16_t id);
+
+/// Open a NitroFS file directly by its FAT offset ID.
+///
+/// This FAT offset ID can be sourced from functions like @see stat,
+/// @see fstat or @see readdir - it is equivalent to the st_ino/d_ino value.
+///
+/// In all other functions, this file behaves identically to one sourced from
+/// @see fopen , and should be closed likewise.
+///
+/// @param id The FAT offset ID of the file (0x0000..0xEFFF).
+/// @param mode The file open mode. Only "r" and "rb" are supported.
+///
+/// @return A valid file pointer; NULL on error.
+FILE *nitroFSFopenById(uint16_t id, const char *mode);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/arm9/libc/dirent.c
+++ b/source/arm9/libc/dirent.c
@@ -168,6 +168,7 @@ struct dirent *readdir(DIR *dirp)
 
     dirp->index++;
     ent->d_off = dirp->index;
+    ent->d_ino = fno.fclust;
 
     strncpy(ent->d_name, fno.fname, sizeof(ent->d_name));
     ent->d_name[sizeof(ent->d_name) - 1] = '\0';

--- a/source/arm9/libc/fatfs/ff.c
+++ b/source/arm9/libc/fatfs/ff.c
@@ -2349,7 +2349,8 @@ static FRESULT dir_read (
 		{	/* On the FAT/FAT32 volume */
 			dp->obj.attr = attr = dp->dir[DIR_Attr] & AM_MASK;	/* Get attribute */
 #if FF_USE_LFN		/* LFN configuration */
-			if (b == DDEM || b == '.' || (int)((attr & ~AM_ARC) == AM_VOL) != vol) {	/* An entry without valid data */
+			/* BlocksDS: (Feature) Avoid filtering dot and dot-dot directories. */
+			if (b == DDEM || /* b == '.' || */ (int)((attr & ~AM_ARC) == AM_VOL) != vol) {	/* An entry without valid data */
 				ord = 0xFF;
 			} else {
 				if (attr == AM_LFN) {	/* An LFN entry is found */
@@ -2368,7 +2369,8 @@ static FRESULT dir_read (
 				}
 			}
 #else		/* Non LFN configuration */
-			if (b != DDEM && b != '.' && attr != AM_LFN && (int)((attr & ~AM_ARC) == AM_VOL) == vol) {	/* Is it a valid entry? */
+			/* BlocksDS: (Feature) Avoid filtering dot and dot-dot directories. */
+			if (b != DDEM && /* b != '.' && */ attr != AM_LFN && (int)((attr & ~AM_ARC) == AM_VOL) == vol) {	/* Is it a valid entry? */
 				break;
 			}
 #endif
@@ -4760,6 +4762,15 @@ FRESULT f_readdir (
 			if (res == FR_NO_FILE) res = FR_OK;	/* Ignore end of directory */
 			if (res == FR_OK) {				/* A valid entry is found */
 				get_fileinfo(dp, fno);		/* Get the object information */
+				/* BlocksDS: (Feature) Write device/cluster information */
+				fno->fpdrv = dp->obj.fs->pdrv;
+#if FF_FS_EXFAT
+				if (fs->fs_type == FS_EXFAT) {
+					fno->fclust = 0; /* FIXME */
+				} else
+#endif
+				fno->fclust = ld_clust(dp->obj.fs, dp->dir);
+				/* BlocksDS: end (Feature) Write device/cluster information */
 				res = dir_next(dp, 0);		/* Increment index for next */
 				if (res == FR_NO_FILE) res = FR_OK;	/* Ignore end of directory now */
 			}
@@ -4844,7 +4855,7 @@ FRESULT f_stat (
 		INIT_NAMBUF(dj.obj.fs);
 		res = follow_path(&dj, path);	/* Follow the file path */
 		if (res == FR_OK) {				/* Follow completed */
-			/* BlocksDS - support origin directory stat(), write device/cluster information */
+			/* BlocksDS: (Feature) Support origin directory stat(), write device/cluster information */
 			if (fno) {
 				fno->fpdrv = dj.obj.fs->pdrv;
 #if FF_FS_EXFAT
@@ -4866,6 +4877,7 @@ FRESULT f_stat (
 					get_fileinfo(&dj, fno);
 				}
 			}
+			/* BlocksDS: end (Feature) Support origin directory stat(), write device/cluster information */
 		}
 		FREE_NAMBUF();
 	}

--- a/source/arm9/libc/nitrofs.c
+++ b/source/arm9/libc/nitrofs.c
@@ -490,8 +490,8 @@ int nitrofs_open(const char *name)
 
 static int nitrofs_stat_file_internal(nitrofs_file_t *fp, struct stat *st)
 {
-    // On NitroFS, st_dev is always 2, while st_ino is the file's unique ID.
-    st->st_dev = 2;
+    // On NitroFS, st_dev is always 128, while st_ino is the file's unique ID.
+    st->st_dev = 128;
     st->st_ino = fp->file_index;
     st->st_size = fp->endofs - fp->offset;
     st->st_blksize = 0x200;

--- a/source/arm9/libc/nitrofs_internal.h
+++ b/source/arm9/libc/nitrofs_internal.h
@@ -45,6 +45,10 @@ typedef struct
     uint16_t file_index;
     // dir opened
     uint16_t dir_opened;
+    // parent directory
+    uint16_t dir_parent;
+    // dotdot offset
+    int16_t dotdot_offset;
 } nitrofs_dir_state_t;
 
 // Forward declarations


### PR DESCRIPTION
* Dot and dot-dot entries are now properly emitted in readdir(). In line with common software expectations, they mirror standard FAT filesystem behaviour, that is are present for all subdirectories. For NitroFS, these entries are emulated accordingly.
* The "d_ino" field in readdir() output is now correctly populated, to match stat() and fstat().
* New functions: `nitroFSOpenById()`, `nitroFSFopenById()`. These allow opening a file by its FAT table ID directly, skipping the cost of any required directory lookups.
* Allow opening NitroFS filesystems which only have a FAT table, but no FNT table, using the above API.

I wasn't sure whether to consider https://github.com/blocksds/sdk/issues/69 a bug or not, but @LunarLambda's analysis makes it clear that despite POSIX saying otherwise, the common Linux-targetting software expectation is for these entries to be present.