### PR TITLE
slot2: Fix title update function

### DIFF
--- a/source/arm9/peripherals/slot2tilt.c
+++ b/source/arm9/peripherals/slot2tilt.c
@@ -21,17 +21,23 @@ bool peripheralSlot2TiltUpdate(slot2TiltPosition *data) {
     if (!peripheralSlot2Open(SLOT2_PERIPHERAL_TILT))
         return false;
 
-    if (!(TILT_X_HIGH & 0x80))
-        return false;
+    bool ok = false;
 
-    if (data)
+    if (TILT_X_HIGH & 0x80)
     {
-        data->x = TILT_X_LOW | ((TILT_X_HIGH & 0x0F) << 8);
-        data->y = TILT_Y_LOW | ((TILT_Y_HIGH & 0x0F) << 8);
+        ok = true;
+
+        if (data)
+        {
+            data->x = TILT_X_LOW | ((TILT_X_HIGH & 0x0F) << 8);
+            data->y = TILT_Y_LOW | ((TILT_Y_HIGH & 0x0F) << 8);
+        }
     }
 
+    // Regardless of whether the data was available or not, send the sample
+    // command so that the next frame the data is available.
     TILT_SAMPLE1 = 0x55;
     TILT_SAMPLE2 = 0xAA;
-    return true;
 
+    return ok;
 }


### PR DESCRIPTION
Reading the X and Y values right after sending the sample command doesn't work, it is needed to give time to the cartridge to update the values.

Games wait until the top bit of TILT_X_HIGH is 1. Instead of that, so that the function isn't blocking, this commit makes it so that the sample command is always sent and you can read the results the next frame.