### PR TITLE
card: nitroFS: Slot-1 NitroFS reads can be done from ARM7

### DIFF
--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Zlib
 //
-// Copyright (c) 2023 Antonio Niño Díaz
+// Copyright (c) 2023-2024 Antonio Niño Díaz
 
 #ifndef LIBNDS_FILESYSTEM_H__
 #define LIBNDS_FILESYSTEM_H__
@@ -69,6 +69,17 @@ int nitroFSOpenById(uint16_t id);
 ///
 /// @return A valid file pointer; NULL on error.
 FILE *nitroFSFopenById(uint16_t id, const char *mode);
+
+/// Select the CPU that will do the NitroFS reads.
+///
+/// When NitroFS detects it's running in an official cartridge, or in an
+/// emulator, this function lets you define the CPU that is in charge of reading
+/// from the cart. By default the ARM7 is in charge of reading the cart. This
+/// function lets you switch to using the ARM9 as well. You may switch between
+/// CPUs at runtime, but be careful to not switch while the card is being read.
+///
+/// @param use_arm9 Set to true to use the ARM9, false to use the ARM7.
+void nitroFSSetReaderCPU(bool use_arm9);
 
 #ifdef __cplusplus
 }

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Zlib
 //
-// Copyright (c) 2023-2024 Antonio Niño Díaz
+// Copyright (c) 2023 Antonio Niño Díaz
 
 #ifndef LIBNDS_FILESYSTEM_H__
 #define LIBNDS_FILESYSTEM_H__
@@ -69,17 +69,6 @@ int nitroFSOpenById(uint16_t id);
 ///
 /// @return A valid file pointer; NULL on error.
 FILE *nitroFSFopenById(uint16_t id, const char *mode);
-
-/// Select the CPU that will do the NitroFS reads.
-///
-/// When NitroFS detects it's running in an official cartridge, or in an
-/// emulator, this function lets you define the CPU that is in charge of reading
-/// from the cart. By default the ARM7 is in charge of reading the cart. This
-/// function lets you switch to using the ARM9 as well. You may switch between
-/// CPUs at runtime, but be careful to not switch while the card is being read.
-///
-/// @param use_arm9 Set to true to use the ARM9, false to use the ARM7.
-void nitroFSSetReaderCPU(bool use_arm9);
 
 #ifdef __cplusplus
 }

--- a/include/nds/arm9/card.h
+++ b/include/nds/arm9/card.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2023-2024 Antonio Niño Díaz
+
+#ifndef LIBNDS_NDS_ARM9_CARD_H__
+#define LIBNDS_NDS_ARM9_CARD_H__
+
+/// @file nds/arm9/card.h
+///
+/// @brief Slot-1 and Slot-2 ARM7 read functions.
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/// Function that asks the ARM7 to read from the slot-1 using card commands.
+///
+/// @param dest Destination buffer.
+/// @param offset NDS ROM offset to read.
+/// @param size Size in bytes to read.
+/// @param flags The read flags.
+/// @return On error it returns true. On success, it returns false.
+bool cardReadArm7(void *dest, size_t offset, size_t size, uint32_t flags);
+
+#endif // LIBNDS_NDS_ARM9_CARD_H__

--- a/include/nds/fifocommon.h
+++ b/include/nds/fifocommon.h
@@ -84,6 +84,7 @@ typedef enum {
     DLDI_WRITE_SECTORS,
     DLDI_CLEAR_STATUS,
     DLDI_SHUTDOWN,
+    SLOT1_CARD_READ,
 } FifoSdmmcCommands;
 
 typedef enum {

--- a/include/nds/fifomessages.h
+++ b/include/nds/fifomessages.h
@@ -88,6 +88,7 @@ typedef struct FifoMessage {
             void *buffer;
             u32 offset;
             u32 size;
+            u32 flags;
         } cardParams;
 
         struct {

--- a/source/arm7/storage/storage_fifo.c
+++ b/source/arm7/storage/storage_fifo.c
@@ -72,6 +72,13 @@ void storageMsgHandler(int bytes, void *user_data)
                                             msg.sdParams.buffer);
             }
             break;
+        case SLOT1_CARD_READ:
+            cardRead(msg.cardParams.buffer,
+                     msg.cardParams.offset,
+                     msg.cardParams.size,
+                     msg.cardParams.flags);
+            retval = 1;
+            break;
     }
 
     fifoIrqEnable();

--- a/source/arm9/storage/card.c
+++ b/source/arm9/storage/card.c
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2023-2024 Antonio Niño Díaz
+
+#include <nds/arm9/cache.h>
+#include <nds/fifocommon.h>
+#include <nds/fifomessages.h>
+#include <nds/memory.h>
+
+// Function to ask the ARM7 to read from the slot-1 using card commands
+bool cardReadArm7(void *dest, size_t offset, size_t size, uint32_t flags)
+{
+    DC_FlushRange(dest, size);
+
+    FifoMessage msg;
+    msg.type = SLOT1_CARD_READ;
+    msg.cardParams.offset = offset;
+    msg.cardParams.size = size;
+    msg.cardParams.buffer = dest;
+    msg.cardParams.flags = flags;
+
+    fifoMutexAcquire(FIFO_STORAGE);
+
+    // Let the ARM7 access the slot-1
+    sysSetCardOwner(BUS_OWNER_ARM7);
+
+    fifoSendDatamsg(FIFO_STORAGE, sizeof(msg), (u8 *)&msg);
+
+    fifoWaitValue32Async(FIFO_STORAGE);
+    DC_InvalidateRange(dest, size);
+
+    int result = fifoGetValue32(FIFO_STORAGE);
+
+    fifoMutexRelease(FIFO_STORAGE);
+
+    return result != 0;
+}


### PR DESCRIPTION
This commit removed the ability of NitroFS Slot-1 reads to be done from the ARM7:

Commit 4514e731afff ("nitrofs: remove ARM7 card read support (only worked with main RAM), fix ARM9 card read support a lot").

However, DLDI or DSi SD reads could still be done from the ARM7.

The result is that games behave differently in emulators than in real hardware. The filesystem asynchronous loading example found in ``examples/filesystem/async_loading`` would work on real hardware, or when emulating DLDI/DSi SD, but not when emulating Slot-1 card reads.

This commit reintroduces that support so that users can optionally ask the ARM7 to do the reads. This isn't important just to save cycles in the ARM9, but to let multithreading work the same way no matter where NitroFS is reading files from (Slot-1 card commands, direct Slot-2 memory reads, DLDI or DSi SD).