### PR TITLE
videoGL: Cast integer to GL_TEXTURE_SIZE_ENUM explicitly

### DIFF
--- a/include/nds/arm9/videoGL.h
+++ b/include/nds/arm9/videoGL.h
@@ -526,7 +526,7 @@ static inline enum GL_TEXTURE_SIZE_ENUM glTexSizeToEnum(int size)
         case 1024:
             return TEXTURE_SIZE_1024;
         default:
-            return -1;
+            return (enum GL_TEXTURE_SIZE_ENUM)-1;
     }
 }
 


### PR DESCRIPTION
The line in question gave an invalid conversion error when included from C++. This change ensures it is valid C and C++.