### PR TITLE
libc: fix bug in readdir()

### DIFF
--- a/source/arm9/libc/dirent.c
+++ b/source/arm9/libc/dirent.c
@@ -161,7 +161,7 @@ struct dirent *readdir(DIR *dirp)
     if (fno.fname[0] == '\0')
     {
         // End of directory reached
-        dirp->index = INDEX_NO_ENTRY;
+        dirp->index = INDEX_END_OF_DIRECTORY;
         errno = 0;
         return NULL;
     }


### PR DESCRIPTION
`readdir()` should set the index to `INDEX_END_OF_DIRECTORY` when it hits the end of a directory, not `INDEX_NO_ENTRY`. This incorrect index caused a behavior where calling `seekdir()` after hitting the end of the directory would then cause it to attempt to read past the end of the directory, fail, and act as if you had just called `rewinddir()` instead.