### PR TITLE
keyboard: Replace keyboardEnd() with keyboardExit() which also deinit…

### DIFF
--- a/include/nds/arm9/keyboard.h
+++ b/include/nds/arm9/keyboard.h
@@ -122,8 +122,13 @@ Keyboard *keyboardGetDefault(void);
 /// @param mainDisplay If true the keyboard will render on the main display.
 /// @param loadGraphics If true the keyboard graphics will be loaded.
 /// @return Returns the initialized keyboard struct.
-Keyboard *keyboardInit(Keyboard *keyboard, int layer, BgType type, BgSize size,
-                       int mapBase, int tileBase, bool mainDisplay, bool loadGraphics);
+static inline Keyboard *keyboardInit(Keyboard *keyboard, int layer, BgType type, BgSize size,
+                                     int mapBase, int tileBase, bool mainDisplay, bool loadGraphics) {
+    Keyboard *keyboardInit_call(Keyboard *keyboard, int layer, BgType type, BgSize size,
+                                int mapBase, int tileBase, bool mainDisplay, bool loadGraphics);
+
+    return keyboardInit_call(keyboard == NULL ? keyboardGetDefault() : keyboard, layer, type, size, mapBase, tileBase, mainDisplay, loadGraphics);
+}
 
 /// Initializes the default keyboard of libnds.
 ///
@@ -135,8 +140,10 @@ Keyboard *keyboardInit(Keyboard *keyboard, int layer, BgType type, BgSize size,
 /// @return A pointer to the current keyboard.
 Keyboard* keyboardDemoInit(void);
 
-/// Hides the current keyboard immediately.
-void keyboardEnd(void);
+/// De-initializes the keyboard system, if initialized.
+///
+/// After calling this, one may de-allocate any custom keyboard struct used.
+void keyboardExit(void);
 
 /// Displays the keyboard.
 void keyboardShow(void);

--- a/source/arm9/keyboard.c
+++ b/source/arm9/keyboard.c
@@ -269,20 +269,13 @@ Keyboard *keyboardGetDefault(void)
     return &defaultKeyboard;
 }
 
-Keyboard *keyboardInit(Keyboard *keyboard, int layer, BgType type, BgSize size,
-                       int mapBase, int tileBase, bool mainDisplay, bool loadGraphics)
+Keyboard *keyboardInit_call(Keyboard *keyboard, int layer, BgType type, BgSize size,
+                            int mapBase, int tileBase, bool mainDisplay, bool loadGraphics)
 {
     if (keyboard)
-    {
         curKeyboard = keyboard;
-    }
     else
-    {
-        if (curKeyboard == NULL)
-            curKeyboard = &defaultKeyboard;
-
         keyboard = curKeyboard;
-    }
 
     *keyboard = defaultKeyboard;
 
@@ -334,19 +327,22 @@ Keyboard *keyboardInit(Keyboard *keyboard, int layer, BgType type, BgSize size,
     return keyboard;
 }
 
-Keyboard *keyboardDemoInit(void)
+void keyboardExit(void)
 {
-    return keyboardInit(keyboardGetDefault(), 3, BgType_Text4bpp, BgSize_T_256x512,
-                        defaultKeyboard.mapBase, defaultKeyboard.tileBase, false, true);
+    if (curKeyboard == NULL)
+        return;
+
+    curKeyboard->visible = 0;
+    bgHide(curKeyboard->background);
+    bgUpdate();
+
+    curKeyboard = NULL;
 }
 
-void keyboardEnd(void)
+Keyboard *keyboardDemoInit(void)
 {
-    Keyboard *keyboard = curKeyboard;
-
-    bgHide(keyboard->background);
-
-    keyboard->visible = 0;
+    return keyboardInit_call(keyboardGetDefault(), 3, BgType_Text4bpp, BgSize_T_256x512,
+                             defaultKeyboard.mapBase, defaultKeyboard.tileBase, false, true);
 }
 
 void keyboardShow(void)


### PR DESCRIPTION
…ializes the pointer, make keyboardInit() not link in the default keyboard when a custom keyboard is used exclusively.