### PR TITLE
fat: nitrofs: Implement get/set FAT file attribute functions

### DIFF
--- a/include/fat.h
+++ b/include/fat.h
@@ -103,6 +103,38 @@ static inline int fatInitLookupCacheFile(FILE *file, uint32_t max_buffer_size) {
 #define FAT_INIT_LOOKUP_CACHE_OUT_OF_MEMORY     -2
 #define FAT_INIT_LOOKUP_CACHE_ALREADY_ALLOCATED -3
 
+// FAT file attributes
+#define ATTR_ARCHIVE    0x20 ///< Archive
+#define ATTR_DIRECTORY  0x10 ///< Directory
+#define ATTR_VOLUME     0x08 ///< Volume (Unused in FatFs)
+#define ATTR_SYSTEM     0x04 ///< System
+#define ATTR_HIDDEN     0x02 ///< Hidden
+#define ATTR_READONLY   0x01 ///< Read only
+
+/// Get FAT attributes of a file.
+///
+/// This function works when used on NitroFS.
+///
+/// On error, this function sets errno to an error code.
+///
+/// @param file Path to the file.
+///
+/// @return A combination of ATTR_* flags with the attributes of the file. On
+///         error, it returns -1.
+int FAT_getAttr(const char *file);
+
+/// Set FAT attributes of a file.
+///
+/// This function fails when used on NitroFS (it's read-only).
+///
+/// On error, this function sets errno to an error code.
+///
+/// @param file Path to the file.
+/// @param attr A combination of ATTR_* flags with the new attributes of the file.
+///
+/// @return 0 on success, -1 on error.
+int FAT_setAttr(const char *file, uint8_t attr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/arm9/libc/nitrofs.c
+++ b/source/arm9/libc/nitrofs.c
@@ -521,6 +521,27 @@ static int nitrofs_stat_file_internal(nitrofs_file_t *f, struct stat *st)
     return 0;
 }
 
+int nitrofs_fat_get_attr(const char *name)
+{
+    if (!nitrofs_local.fnt_offset)
+    {
+        errno = ENODEV;
+        return -1;
+    }
+
+    int32_t res = nitrofs_path_resolve(name);
+    if (res < 0)
+    {
+        errno = ENOENT;
+        return -1;
+    }
+
+    if (res >= 0xF000)
+        return ATTR_DIRECTORY | ATTR_READONLY;
+
+    return ATTR_READONLY;
+}
+
 int nitrofs_stat(const char *name, struct stat *st)
 {
     if (!nitrofs_local.fnt_offset)

--- a/source/arm9/libc/nitrofs_internal.h
+++ b/source/arm9/libc/nitrofs_internal.h
@@ -68,5 +68,6 @@ off_t nitrofs_lseek(int fd, off_t offset, int whence);
 int nitrofs_close(int fd);
 int nitrofs_stat(const char *name, struct stat *st);
 int nitrofs_fstat(int fd, struct stat *st);
+int nitrofs_fat_get_attr(const char *name);
 
 #endif // NITROFS_INTERNAL_H__


### PR DESCRIPTION
This is done for compatibility with libfat. It may be useful in some situations.

Note that in NitroFS it is only possible to get file attributes, as it is a read-only filesystem.