### PR TITLE
include: rewrite sys/dirent.h, fix minor issues

### DIFF
--- a/include/machine/_types.h
+++ b/include/machine/_types.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2024 Adrian "asie" Siekierka
+
+#ifndef MACHINE__TYPES_H__
+#define MACHINE__TYPES_H__
+
+// Define some platform-specific types for newlib/picolibc.
+
+#include <stdint.h>
+#include <machine/_default_types.h>
+
+typedef uint32_t __ino_t;
+typedef uint64_t __ino64_t;
+#define __machine_ino_t_defined
+
+typedef int32_t _off_t;
+#define __machine_off_t_defined
+
+#endif

--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -1,12 +1,6 @@
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Zlib
 //
-// Copyright 2007
-// International Business Machines Corporation,
-// Sony Computer Entertainment, Incorporated,
-// Toshiba Corporation,
-// All rights reserved.
-//
-// Copyright (c) 2023 Antonio Niño Díaz
+// Copyright (c) 2024 Adrian "asie" Siekierka
 
 #ifndef SYS_DIRENT_H__
 #define SYS_DIRENT_H__
@@ -17,36 +11,61 @@ extern "C" {
 
 #include <sys/types.h>
 
-#define MAXNAMLEN   255
-
-#define DT_UNKNOWN  0
-#define DT_FIFO     1
-#define DT_CHR      2
-#define DT_DIR      3
-#define DT_BLK      4
-#define DT_REG      5
-#define DT_LNK      6
-#define DT_SOCK     7
-#define DT_WHT      8
+/// UTF-8 necessitates a maximum of three bytes for any UTF-16 codepoint.
+#define MAXNAMLEN (255 * 3)
 
 struct dirent {
-    ino_t           d_ino;    // Inode number
-    off_t           d_off;    // Value that would be returned by telldir()
-    unsigned short  d_reclen; // Length of this record
-    unsigned char   d_type;   // Type of file; not supported by all filesystems
-    char            d_name[MAXNAMLEN + 1]; // Null-terminated filename
+    /// Inode number. Implementation-defined.
+    ///
+    /// For FAT filesystems, this stores the cluster the file is located on.
+    /// For NitroFS filesystems, this stores the ID of the file.
+    ino_t d_ino;
+
+    /// Index within the directory.
+    off_t d_off;
+
+    /// File/directory name.
+    char d_name[MAXNAMLEN + 1];
+
+    /// File/directory type.
+    ///
+    /// For BlocksDS, this will typically be either DT_REG (file), or DT_DIR
+    /// (directory).
+    unsigned char d_type;
+
+    /// Size of this directory entry.
+    unsigned short d_reclen;
 };
 
 typedef struct {
-    // Private pointer to internal state of the directory.
-    void    *dp;
-    // Type of the private pointer.
-    int     dptype;
-    // Index of the current entry (for telldir() and seekdir()).
-    int     index;
-    // Allow one readdir for each opendir, and store the data here.
-    struct  dirent dirent;
+    // Buffer containing the returned directory entry.
+    struct dirent dirent;
+
+    // Pointer to native directory structure.
+    void *dp;
+
+    // Index within the directory.
+    off_t index;
+
+    // Type of native directory structure pointer.
+    uint8_t dptype;
 } DIR;
+
+/// Unknown file type.
+#define DT_UNKNOWN 0
+
+/// Regular file.
+#define DT_REG 1
+
+/// Directory.
+#define DT_DIR 2
+
+// The following are not used by BlocksDS, but provided for compatibility.
+#define DT_FIFO 3
+#define DT_CHR 4
+#define DT_BLK 5
+#define DT_LNK 6
+#define DT_SOCK 7
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I created a new `sys/dirent.h` by deleting the old one and writing a new one based on [the POSIX specification](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/), as well as [the GNU libc manual](https://www.gnu.org/software/libc/manual/html_node/Directory-Entries.html) and other manuals for BSD/GNU-specific extensions.

This PR means we can finally remove the last disputed bit of BSD/MIT-style licensing. This PR also fixes some minor issues, including but possibly not limited to:

- `d_ino` is now properly documented, and its (and `d_off`)'s sizes are controlled by us (in `machine/_types.h`) to match BlocksDS's requirements,
- `MAXNAMLEN` is now set to the correct maximum value that FatFS can output.