### PR TITLE
libc: Add support for stack smash canaries in debug variants.

### DIFF
--- a/Makefile.arm7
+++ b/Makefile.arm7
@@ -19,6 +19,8 @@ INCLUDEDIRS	:= include source source/common/ndsabi/
 
 ifneq ($(DEBUG),1)
 DEFINES		:= -DNDEBUG
+else
+CFLAGS		+= -fstack-protector-strong
 endif
 
 # Libraries

--- a/Makefile.arm9
+++ b/Makefile.arm9
@@ -21,6 +21,8 @@ BINDIRS		:= source/arm9
 
 ifneq ($(DEBUG),1)
 DEFINES		:= -DNDEBUG
+else
+CFLAGS		+= -fstack-protector-strong
 endif
 
 # Libraries

--- a/source/common/libc/exit.c
+++ b/source/common/libc/exit.c
@@ -83,3 +83,17 @@ ARM_CODE void _exit(int rc)
 
     while (1);
 }
+
+// As this file is always linked in by the crt0, it makes for a good place
+// to include newlib/picolibc stack smash protection overrides.
+uintptr_t __stack_chk_guard = 0x00000aff;
+
+__attribute__((noreturn))
+THUMB_CODE void __stack_chk_fail(void) {
+    // This function causes an undefined instruction exception to crash the CPU
+    // in a controlled way.
+    //
+    // See common/libc/locks.c for more information.
+    asm volatile inline(".hword 0xE800 | 0xBAD");
+    __builtin_unreachable();
+}


### PR DESCRIPTION
I have checked the resulting ELFs, but haven't actually tried to smash the stack - however, I followed the ideas of `retarget_lock_crash`.

(Stack smash protection will work in *non*-debug variants, too, albeit without libnds functions themselves being protected.)