### PR TITLE
arm7: Rewrite touch code, refactor SPI, RTC code

### DIFF
--- a/include/nds.h
+++ b/include/nds.h
@@ -96,7 +96,11 @@
 /// - @ref nds/arm7/clock.h "RTC utilities"
 /// - @ref nds/arm7/input.h "Keypad and touch pad ARM7 helpers"
 /// - @ref nds/arm7/audio.h "Audio and microphone helpers"
-/// - @ref nds/arm7/tmio.h "TMIO ARM7 module"
+/// - @ref nds/arm7/touch.h "Touch screen helpers"
+/// - @ref nds/arm7/serial.h "SPI bus controller"
+/// - @ref nds/arm7/firmware.h "Firmware flash access helpers"
+/// - @ref nds/arm7/tsc.h "DS Touchscreen/Sound controller helpers"
+/// - @ref nds/arm7/tmio.h "DSi TMIO ARM7 module"
 /// - @ref nds/arm7/gpio.h "DSi GPIO ARM7 definitions and helpers"
 ///
 /// @section debug_api Debugging
@@ -182,6 +186,7 @@ extern "C" {
 #    include <nds/arm7/camera.h>
 #    include <nds/arm7/clock.h>
 #    include <nds/arm7/codec.h>
+#    include <nds/arm7/firmware.h>
 #    include <nds/arm7/gpio.h>
 #    include <nds/arm7/i2c.h>
 #    include <nds/arm7/input.h>
@@ -189,6 +194,7 @@ extern "C" {
 #    include <nds/arm7/serial.h>
 #    include <nds/arm7/tmio.h>
 #    include <nds/arm7/touch.h>
+#    include <nds/arm7/tsc.h>
 #endif // ARM7
 
 #ifdef __cplusplus

--- a/include/nds/arm7/clock.h
+++ b/include/nds/arm7/clock.h
@@ -24,6 +24,26 @@ extern "C" {
 #include <nds/arm7/serial.h>
 #include <nds/system.h>
 
+// RTC control registers
+#define REG_RTCCNT              (*(vu16 *)0x04000138)
+#define REG_RTCCNT8             (*(vu8 *)0x04000138)
+
+// Pin defines on REG_RTCCNT
+
+#define RTCCNT_SIO     (1 << 0)
+#define RTCCNT_SIO_OUT (1 << 4)
+#define RTCCNT_SCK     (1 << 1)
+#define RTCCNT_SCK_OUT (1 << 5)
+#define RTCCNT_CS      (1 << 2)
+#define RTCCNT_CS_OUT  (1 << 6)
+
+#define RTCCNT_CS_0    (RTCCNT_CS_OUT)
+#define RTCCNT_CS_1    (RTCCNT_CS_OUT | RTCCNT_CS)
+#define RTCCNT_SCK_0   (RTCCNT_SCK_OUT)
+#define RTCCNT_SCK_1   (RTCCNT_SCK_OUT | RTCCNT_SCK)
+#define RTCCNT_SIO_0   (RTCCNT_SIO_OUT)
+#define RTCCNT_SIO_1   (RTCCNT_SIO_OUT | RTCCNT_SIO)
+
 // RTC registers
 #define WRITE_STATUS_REG1   0x60
 #define READ_STATUS_REG1    0x61

--- a/include/nds/arm7/codec.h
+++ b/include/nds/arm7/codec.h
@@ -3,8 +3,6 @@
 //
 // Copyright (C) 2017 fincs
 
-// DSi "codec" Touchscreen/Sound Controller control for ARM7
-
 #ifndef LIBNDS_NDS_ARM7_CODEC_H__
 #define LIBNDS_NDS_ARM7_CODEC_H__
 
@@ -15,6 +13,10 @@ extern "C" {
 #ifndef ARM7
 #error DSi TSC is only available on the ARM7
 #endif
+
+/// @file nds/arm7/codec.h
+///
+/// @brief DSi "codec" Touchscreen/Sound Controller control for ARM7
 
 #include <nds/arm7/serial.h>
 #include <nds/memory.h>
@@ -27,10 +29,10 @@ static inline bool cdcIsAvailable(void)
 }
 
 enum cdcBanks {
-    CDC_CONTROL     = 0x00, // Chip control
-    CDC_SOUND       = 0x01, // ADC/DAC control
-    CDC_TOUCHCNT    = 0x03, // TSC control
-    CDC_TOUCHDATA    = 0xFC, // TSC data buffer
+    CDC_CONTROL     = 0x00, ///< Chip control
+    CDC_SOUND       = 0x01, ///< ADC/DAC control
+    CDC_TOUCHCNT    = 0x03, ///< TSC control
+    CDC_TOUCHDATA    = 0xFC, ///< TSC data buffer
 };
 
 // TODO: These lists are incomplete.

--- a/include/nds/arm7/codec.h
+++ b/include/nds/arm7/codec.h
@@ -19,6 +19,7 @@ extern "C" {
 /// @brief DSi "codec" Touchscreen/Sound Controller control for ARM7
 
 #include <nds/arm7/serial.h>
+#include <nds/arm7/touch.h>
 #include <nds/memory.h>
 #include <nds/system.h>
 #include <nds/touch.h>
@@ -209,8 +210,16 @@ void cdcWriteReg24(u8 bank, u8 reg, u32 value);
 
 // Touchscreen functions
 void cdcTouchInit(void);
+
+/**
+ * @brief Check if the DSi CODEC is registering pen input.
+ */
 bool cdcTouchPenDown(void);
-bool cdcTouchRead(touchPosition* pos);
+
+/**
+ * @brief Read raw touch data from the DSi CODEC.
+ */
+bool cdcTouchReadData(touchRawArray* data);
 
 #ifdef __cplusplus
 }

--- a/include/nds/arm7/firmware.h
+++ b/include/nds/arm7/firmware.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2024 Adrian "asie" Siekierka
+
+#ifndef LIBNDS_NDS_ARM7_FIRMWARE_H__
+#define LIBNDS_NDS_ARM7_FIRMWARE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef ARM7
+#error Firmware header is for ARM7 only
+#endif
+
+/// @file nds/arm7/firmware.h
+///
+/// @brief DS firmware flash ARM7 helpers.
+
+#include <nds/ndstypes.h>
+
+// Firmware commands
+#define FIRMWARE_WREN           0x06 ///< Write Enable
+#define FIRMWARE_WRDI           0x04 ///< Write Disable
+#define FIRMWARE_RDID           0x9F ///< Read JEDEC ID
+#define FIRMWARE_RDSR           0x05 ///< Read Status Register
+#define FIRMWARE_READ           0x03 ///< Read Data Bytes
+#define FIRMWARE_PW             0x0A ///< Page Write
+#define FIRMWARE_PP             0x02 ///< Page Program
+#define FIRMWARE_FAST           0x0B ///< Fast Read Data Bytes (preceded by a dummy byte)
+#define FIRMWARE_PE             0xDB ///< Page Erase
+#define FIRMWARE_SE             0xD8 ///< Sector Erase
+#define FIRMWARE_DP             0xB9 ///< Deep Power Down
+#define FIRMWARE_RDP            0xAB ///< Release from Deep Power Down
+
+/**
+ * @brief Read data from the firmware flash.
+ */
+void readFirmware(u32 address, void *destination, u32 size);
+
+/**
+ * @brief Read the JEDEC ID of the firmware flash.
+ */
+int readFirmwareJEDEC(u8 *destination, u32 size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/nds/arm7/firmware.h
+++ b/include/nds/arm7/firmware.h
@@ -18,6 +18,7 @@ extern "C" {
 /// @brief DS firmware flash ARM7 helpers.
 
 #include <nds/ndstypes.h>
+#include <nds/system.h>
 
 // Firmware commands
 #define FIRMWARE_WREN           0x06 ///< Write Enable
@@ -32,11 +33,6 @@ extern "C" {
 #define FIRMWARE_SE             0xD8 ///< Sector Erase
 #define FIRMWARE_DP             0xB9 ///< Deep Power Down
 #define FIRMWARE_RDP            0xAB ///< Release from Deep Power Down
-
-/**
- * @brief Read data from the firmware flash.
- */
-void readFirmware(u32 address, void *destination, u32 size);
 
 /**
  * @brief Read the JEDEC ID of the firmware flash.

--- a/include/nds/arm7/touch.h
+++ b/include/nds/arm7/touch.h
@@ -24,22 +24,32 @@ extern "C" {
 #include <nds/touch.h>
 
 /**
- * @brief Read temperature from the NDS-mode TSC.
- *
- * Note that this does not work on DSi/3DS consoles.
- * It is also not very inaccurate - calibration is required
- * to get a more accurate reading.
- * 
- * @param t1 First measurement output.
- * @param t2 Second measurement output.
- * @return u32 Approximate temperature, in Kelvins.
- */
-u32 touchReadTemperature(int *t1, int *t2);
-
-/**
  * @brief Initialize the touch subsystem (NDS/DSi).
  */
 void touchInit(void);
+
+/**
+ * @brief Apply calibration to raw X/Y touch screen measurements.
+ * 
+ * @param rawx Raw X value
+ * @param rawy Raw Y value
+ * @param px Calibrated X value
+ * @param py Calibrated Y value
+ */
+void touchApplyCalibration(u16 rawx, u16 rawy, u16 *px, u16 *py);
+
+// Do not modify the memory layout; touchReadData() functions rely on it.
+typedef struct {
+    u16 rawX[5];
+    u16 rawY[5];
+    u16 z1[5];
+    u16 z2[5];
+} touchRawArray;
+
+/**
+ * @brief Read a complete, raw touch measurement into the provided buffer.
+ */
+void touchReadData(touchRawArray *data);
 
 /**
  * @brief Read a touch X/Y position into the provided buffer.

--- a/include/nds/arm7/touch.h
+++ b/include/nds/arm7/touch.h
@@ -5,8 +5,6 @@
 // Copyright (C) 2005 Jason Rogers (dovoto)
 // Copyright (C) 2005 Dave Murphy (WinterMute)
 
-// Microphone control for the ARM7
-
 #ifndef LIBNDS_NDS_ARM7_TOUCH_H__
 #define LIBNDS_NDS_ARM7_TOUCH_H__
 
@@ -18,25 +16,39 @@ extern "C" {
 #error Touch screen is only available on the ARM7
 #endif
 
+/// @file nds/arm7/touch.h
+///
+/// @brief High-level touchscreen functions for ARM7
+
 #include <nds/arm7/serial.h>
 #include <nds/touch.h>
 
-#define SCREEN_WIDTH            256
-#define SCREEN_HEIGHT           192
+/**
+ * @brief Read temperature from the NDS-mode TSC.
+ *
+ * Note that this does not work on DSi/3DS consoles.
+ * It is also not very inaccurate - calibration is required
+ * to get a more accurate reading.
+ * 
+ * @param t1 First measurement output.
+ * @param t2 Second measurement output.
+ * @return u32 Approximate temperature, in Kelvins.
+ */
+u32 touchReadTemperature(int *t1, int *t2);
 
-#define TSC_MEASURE_TEMP1       0x84
-#define TSC_MEASURE_Y           0x90
-#define TSC_MEASURE_BATTERY     0xA4
-#define TSC_MEASURE_Z1          0xB4
-#define TSC_MEASURE_Z2          0xC4
-#define TSC_MEASURE_X           0xD0
-#define TSC_MEASURE_AUX         0xE4
-#define TSC_MEASURE_TEMP2       0xF4
-
+/**
+ * @brief Initialize the touch subsystem (NDS/DSi).
+ */
 void touchInit(void);
+
+/**
+ * @brief Read a touch X/Y position into the provided buffer.
+ */
 void touchReadXY(touchPosition *touchPos);
-uint16_t touchRead(uint32_t command);
-uint32_t touchReadTemperature(int *t1, int *t2);
+
+/**
+ * @brief Returns true if the screen is currently being touched.
+ */
 bool touchPenDown(void);
 
 #ifdef __cplusplus

--- a/include/nds/arm7/tsc.h
+++ b/include/nds/arm7/tsc.h
@@ -13,10 +13,11 @@ extern "C" {
 #error TSC is only available on the ARM7
 #endif
 
-/// @file nds/arm7/touch.h
+/// @file nds/arm7/tsc.h
 ///
 /// @brief DS Touchscreen/Sound Controller control for ARM7
 
+#include <nds/arm7/touch.h>
 #include <nds/arm7/serial.h>
 
 #define TSC_START               0x80
@@ -38,6 +39,14 @@ extern "C" {
 #define TSC_MEASURE_TEMP2       (TSC_START | TSC_CHANNEL(7) | TSC_CONVERT_12BIT | TSC_MODE_SER)
 
 /**
+ * @brief Check if the NDS-mode TSC is registering pen input.
+ */
+static inline bool tscTouchPenDown(void)
+{
+    return !(REG_KEYXY & KEYXY_TOUCH);
+}
+
+/**
  * @brief Read a single 12-bit measurement from the NDS-mode TSC.
  * 
  * @param command Measurement command.
@@ -53,6 +62,20 @@ u16 tscRead(u32 command);
  * @param count Number of measurements to read.
  */
 void tscMeasure(u32 command, u16 *buffer, u32 count);
+
+/**
+ * @brief Read raw touch data from the NDS-mode TSC.
+ */
+bool tscTouchReadData(touchRawArray* data);
+
+/**
+ * @brief Read temperature from the NDS-mode TSC.
+ *
+ * Note that it is not very accurate.
+ * 
+ * @return s32 Approximate temperature, in 20.12 fixed point, as Celsius degrees.
+ */
+s32 tscReadTemperature(void);
 
 #ifdef __cplusplus
 }

--- a/include/nds/arm7/tsc.h
+++ b/include/nds/arm7/tsc.h
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2024 Adrian "asie" Siekierka
+
+#ifndef LIBNDS_NDS_ARM7_TSC_H__
+#define LIBNDS_NDS_ARM7_TSC_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef ARM7
+#error TSC is only available on the ARM7
+#endif
+
+/// @file nds/arm7/touch.h
+///
+/// @brief DS Touchscreen/Sound Controller control for ARM7
+
+#include <nds/arm7/serial.h>
+
+#define TSC_START               0x80
+#define TSC_CHANNEL(n)          ((n) << 4)
+#define TSC_CONVERT_12BIT       0x00 ///< Convert to 12-bit samples
+#define TSC_CONVERT_8BIT        0x08 ///< Convert to 8-bit samples
+#define TSC_MODE_DFR            0x00 ///< Differential Reference mode
+#define TSC_MODE_SER            0x04 ///< Single-Ended Reference mode
+#define TSC_POWER_AUTO          0x00 ///< Auto Power Down mode
+#define TSC_POWER_ON            0x01 ///< Full Power mode
+
+#define TSC_MEASURE_TEMP1       (TSC_START | TSC_CHANNEL(0) | TSC_CONVERT_12BIT | TSC_MODE_SER)
+#define TSC_MEASURE_Y           (TSC_START | TSC_CHANNEL(1) | TSC_CONVERT_12BIT | TSC_MODE_DFR)
+#define TSC_MEASURE_BATTERY     (TSC_START | TSC_CHANNEL(2) | TSC_CONVERT_12BIT | TSC_MODE_SER)
+#define TSC_MEASURE_Z1          (TSC_START | TSC_CHANNEL(3) | TSC_CONVERT_12BIT | TSC_MODE_SER)
+#define TSC_MEASURE_Z2          (TSC_START | TSC_CHANNEL(4) | TSC_CONVERT_12BIT | TSC_MODE_SER)
+#define TSC_MEASURE_X           (TSC_START | TSC_CHANNEL(5) | TSC_CONVERT_12BIT | TSC_MODE_DFR)
+#define TSC_MEASURE_AUX         (TSC_START | TSC_CHANNEL(6) | TSC_CONVERT_12BIT | TSC_MODE_SER)
+#define TSC_MEASURE_TEMP2       (TSC_START | TSC_CHANNEL(7) | TSC_CONVERT_12BIT | TSC_MODE_SER)
+
+/**
+ * @brief Read a single 12-bit measurement from the NDS-mode TSC.
+ * 
+ * @param command Measurement command.
+ * @return u16 Measured value, from 0 to 4095.
+ */
+u16 tscRead(u32 command);
+
+/**
+ * @brief Read multiple 12-bit measurements from the NDS-mode TSC.
+ * 
+ * @param command Measurement command.
+ * @param buffer Output buffer.
+ * @param count Number of measurements to read.
+ */
+void tscMeasure(u32 command, u16 *buffer, u32 count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LIBNDS_NDS_ARM7_TSC_H__

--- a/include/nds/arm9/video.h
+++ b/include/nds/arm9/video.h
@@ -73,6 +73,7 @@ extern "C" {
 
 #include <nds/arm9/sassert.h>
 #include <nds/ndstypes.h>
+#include <nds/system.h>
 
 extern u16 mosaicShadow;
 extern u16 mosaicShadowSub;
@@ -113,12 +114,6 @@ extern u16 mosaicShadowSub;
 /// Macro to convert 5 bit r, g, b components plus 1 bit alpha into a single 16
 /// bit ARGB triplet.
 #define ARGB16(a, r, g, b)  (((a) << 15) | (r) | ((g) << 5) | ((b) << 10))
-
-/// Screen height in pixels.
-#define SCREEN_HEIGHT 192
-
-/// Screen width in pixels.
-#define SCREEN_WIDTH  256
 
 // VRAM Control
 #define VRAM_CR         (*(vu32 *)0x04000240)

--- a/include/nds/registers_alt.h
+++ b/include/nds/registers_alt.h
@@ -302,4 +302,9 @@
 
 #define SOUND_BIAS          REG_SOUNDBIAS
 
+#ifdef ARM7
+#define RTC_CR              REG_RTCCNT
+#define RTC_CR8             REG_RTCCNT8
+#endif
+
 #endif // LIBNDS_NDS_REGISTERS_ALT_H__

--- a/include/nds/registers_alt.h
+++ b/include/nds/registers_alt.h
@@ -307,4 +307,8 @@
 #define RTC_CR8             REG_RTCCNT8
 #endif
 
+#ifdef ARM9
+#define HALT_CR             REG_HALTCNT
+#endif
+
 #endif // LIBNDS_NDS_REGISTERS_ALT_H__

--- a/include/nds/system.h
+++ b/include/nds/system.h
@@ -122,6 +122,16 @@ static inline bool isHwDebugger(void)
     return __debugger_unit;
 }
 
+/**
+ * @brief Write bytes at a specified address to firmware flash.
+ */
+int writeFirmware(u32 address, void *buffer, u32 length);
+
+/**
+ * @brief Read bytes at a specified address from firmware flash.
+ */
+void readFirmware(u32 address, void *buffer, u32 length);
+
 // ARM9 section
 // ------------
 
@@ -176,9 +186,6 @@ static inline void systemShutDown(void)
 {
     powerOn(PM_SYSTEM_PWR);
 }
-
-void readFirmware(u32 address, void *buffer, u32 length);
-int writeFirmware(u32 address, void *buffer, u32 length);
 
 /// Gets the DS battery level
 ///
@@ -277,18 +284,25 @@ typedef enum {
 #define PM_LED_CONTROL_MASK (3 << 4)
 #define PM_LED_CONTROL(m)   ((m) << 4)
 
-// Install the FIFO power handler.
+/**
+ * @brief Install the system FIFO handlers.
+ * 
+ * This handles power management, DSi SD card access, and firmware flash
+ * access.
+ */
 void installSystemFIFO(void);
-
-// Cause the DS to enter low power mode.
-void systemSleep(void);
 
 // Internal. Check if sleep mode is enabled.
 int sleepEnabled(void);
 
-// Read/write a power management register
+/**
+ * @brief Write to a power management register.
+ */
 int writePowerManagement(int reg, int command);
 
+/**
+ * @brief Read from a power management register.
+ */
 static inline int readPowerManagement(int reg)
 {
     return writePowerManagement(reg | PM_READ_REGISTER, 0);
@@ -304,6 +318,10 @@ static inline void powerOff(uint32_t bits)
     REG_POWERCNT &= ~bits;
 }
 
+/**
+ * @brief Read user settings/personal data from firmware flash to a shared
+ * memory location.
+ */
 bool readUserSettings(void);
 void systemShutDown(void);
 

--- a/include/nds/system.h
+++ b/include/nds/system.h
@@ -49,9 +49,9 @@ typedef enum
 
 /// Halt control register.
 ///
-/// Writing 0x40 to HALT_CR activates GBA mode. HALT_CR can only be accessed via
+/// Writing 0x40 to REG_HALTCNT activates GBA mode. REG_HALTCNT can only be accessed via
 /// the BIOS.
-#define HALT_CR (*(vu16*)0x04000300)
+#define REG_HALTCNT (*(vu16*)0x04000300)
 
 /// Power control register.
 ///

--- a/include/nds/system.h
+++ b/include/nds/system.h
@@ -24,6 +24,12 @@ extern "C" {
 
 #include <nds/ndstypes.h>
 
+/// Screen height in pixels.
+#define SCREEN_HEIGHT 192
+
+/// Screen width in pixels.
+#define SCREEN_WIDTH  256
+
 /// LCD status register.
 #define REG_DISPSTAT (*(vu16*)0x04000004)
 
@@ -279,10 +285,6 @@ void systemSleep(void);
 
 // Internal. Check if sleep mode is enabled.
 int sleepEnabled(void);
-
-// Warning: These functions use the SPI chain, and are thus 'critical' sections,
-// make sure to disable interrupts during the call if you've got a VBlank IRQ
-// polling the touch screen, etc...
 
 // Read/write a power management register
 int writePowerManagement(int reg, int command);

--- a/include/nds/touch.h
+++ b/include/nds/touch.h
@@ -22,8 +22,8 @@ extern "C" {
 typedef struct touchPosition {
     u16 rawx; ///< Raw x value from the A2D
     u16 rawy; ///< Raw y value from the A2D
-    u16 px;   ///< Processes pixel X value
-    u16 py;   ///< Processes pixel Y value
+    u16 px;   ///< Processed pixel X value
+    u16 py;   ///< Processed pixel Y value
     u16 z1;   ///< Raw cross panel resistance
     u16 z2;   ///< Raw cross panel resistance
 } touchPosition;

--- a/source/arm7/clock.c
+++ b/source/arm7/clock.c
@@ -20,16 +20,6 @@
 // Delay (in swiDelay units) for each bit transfer
 #define RTC_DELAY 48
 
-// Pin defines on RTC_CR
-#define CS_0    (1 << 6)
-#define CS_1    ((1 << 6) | (1 << 2))
-#define SCK_0   (1 << 5)
-#define SCK_1   ((1 << 5) | (1 << 1))
-#define SIO_0   (1 << 4)
-#define SIO_1   ((1 << 4) | (1 << 0))
-#define SIO_out (1 << 4)
-#define SIO_in  (1)
-
 void BCDToInteger(uint8_t *data, uint32_t length)
 {
     for (u32 i = 0; i < length; i++)
@@ -53,9 +43,9 @@ void rtcTransaction(uint8_t *command, uint32_t commandLength, uint8_t *result,
     uint8_t data;
 
     // Raise CS
-    RTC_CR8 = CS_0 | SCK_1 | SIO_1;
+    REG_RTCCNT8 = RTCCNT_CS_0 | RTCCNT_SCK_1 | RTCCNT_SIO_1;
     swiDelay(RTC_DELAY);
-    RTC_CR8 = CS_1 | SCK_1 | SIO_1;
+    REG_RTCCNT8 = RTCCNT_CS_1 | RTCCNT_SCK_1 | RTCCNT_SIO_1;
     swiDelay(RTC_DELAY);
 
     // Write command byte (high bit first)
@@ -63,10 +53,10 @@ void rtcTransaction(uint8_t *command, uint32_t commandLength, uint8_t *result,
 
     for (bit = 0; bit < 8; bit++)
     {
-        RTC_CR8 = CS_1 | SCK_0 | SIO_out | (data >> 7);
+        REG_RTCCNT8 = RTCCNT_CS_1 | RTCCNT_SCK_0 | RTCCNT_SIO_OUT | (data >> 7);
         swiDelay(RTC_DELAY);
 
-        RTC_CR8 = CS_1 | SCK_1 | SIO_out | (data >> 7);
+        REG_RTCCNT8 = RTCCNT_CS_1 | RTCCNT_SCK_1 | RTCCNT_SIO_OUT | (data >> 7);
         swiDelay(RTC_DELAY);
 
         data = data << 1;
@@ -79,10 +69,10 @@ void rtcTransaction(uint8_t *command, uint32_t commandLength, uint8_t *result,
 
         for (bit = 0; bit < 8; bit++)
         {
-            RTC_CR8 = CS_1 | SCK_0 | SIO_out | (data & 1);
+            REG_RTCCNT8 = RTCCNT_CS_1 | RTCCNT_SCK_0 | RTCCNT_SIO_OUT | (data & 1);
             swiDelay(RTC_DELAY);
 
-            RTC_CR8 = CS_1 | SCK_1 | SIO_out | (data & 1);
+            REG_RTCCNT8 = RTCCNT_CS_1 | RTCCNT_SCK_1 | RTCCNT_SIO_OUT | (data & 1);
             swiDelay(RTC_DELAY);
 
             data = data >> 1;
@@ -96,20 +86,20 @@ void rtcTransaction(uint8_t *command, uint32_t commandLength, uint8_t *result,
 
         for (bit = 0; bit < 8; bit++)
         {
-            RTC_CR8 = CS_1 | SCK_0;
+            REG_RTCCNT8 = RTCCNT_CS_1 | RTCCNT_SCK_0;
             swiDelay(RTC_DELAY);
 
-            RTC_CR8 = CS_1 | SCK_1;
+            REG_RTCCNT8 = RTCCNT_CS_1 | RTCCNT_SCK_1;
             swiDelay(RTC_DELAY);
 
-            if (RTC_CR8 & SIO_in)
+            if (REG_RTCCNT8 & RTCCNT_SIO)
                 data |= (1 << bit);
         }
         *result++ = data;
     }
 
     // Finish up by dropping CS low
-    RTC_CR8 = CS_0 | SCK_1;
+    REG_RTCCNT8 = RTCCNT_CS_0 | RTCCNT_SCK_1;
     swiDelay(RTC_DELAY);
 }
 

--- a/source/arm7/firmware.c
+++ b/source/arm7/firmware.c
@@ -5,18 +5,12 @@
 
 #include <string.h>
 
+#include <nds/arm7/firmware.h>
 #include <nds/arm7/serial.h>
 #include <nds/fifocommon.h>
 #include <nds/fifomessages.h>
 #include <nds/interrupts.h>
 #include <nds/system.h>
-
-static u8 readwriteSPI(u8 data)
-{
-    REG_SPIDATA = data;
-    SerialWaitBusy();
-    return REG_SPIDATA;
-}
 
 void readFirmware(u32 address, void *destination, u32 size)
 {
@@ -24,17 +18,17 @@ void readFirmware(u32 address, void *destination, u32 size)
     u8 *buffer = destination;
 
     // Read command
-    REG_SPICNT = SPI_ENABLE | SPI_BYTE_MODE | SPI_CONTINUOUS | SPI_DEVICE_FIRMWARE;
-    readwriteSPI(FIRMWARE_READ);
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_FIRMWARE | SPI_CONTINUOUS;
+    spiWrite(FIRMWARE_READ);
 
     // Set the address
-    readwriteSPI((address >> 16) & 0xFF);
-    readwriteSPI((address >> 8) & 0xFF);
-    readwriteSPI(address & 0xFF);
+    spiWrite((address >> 16) & 0xFF);
+    spiWrite((address >> 8) & 0xFF);
+    spiWrite(address & 0xFF);
 
     // Read the data
     for (u32 i = 0; i < size; i++)
-        buffer[i] = readwriteSPI(0);
+        buffer[i] = spiRead();
 
     REG_SPICNT = 0;
     leaveCriticalSection(oldIME);
@@ -50,10 +44,11 @@ int readFirmwareJEDEC(u8 *destination, u32 size)
         return -2;
 
     int oldIME = enterCriticalSection();
-    REG_SPICNT = SPI_ENABLE | SPI_BYTE_MODE | SPI_CONTINUOUS | SPI_DEVICE_FIRMWARE;
-    readwriteSPI(FIRMWARE_RDID); // get JEDEC
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_FIRMWARE | SPI_CONTINUOUS;
+    spiWrite(FIRMWARE_RDID); // get JEDEC
+
     for (int i = 0; i < 3; i++)
-        destination[i] = readwriteSPI(0);
+        destination[i] = spiRead();
 
     REG_SPICNT = 0;
     leaveCriticalSection(oldIME);
@@ -72,34 +67,34 @@ static int writeFirmwarePage(u32 address, u8 *buffer)
     int oldIME = enterCriticalSection();
 
     // Write enable
-    REG_SPICNT = SPI_ENABLE | SPI_CONTINUOUS | SPI_DEVICE_NVRAM;
-    readwriteSPI(FIRMWARE_WREN);
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_FIRMWARE | SPI_CONTINUOUS;
+    spiWrite(FIRMWARE_WREN);
     REG_SPICNT = 0;
 
     // Wait for Write Enable Latch to be set
-    REG_SPICNT = SPI_ENABLE | SPI_CONTINUOUS | SPI_DEVICE_NVRAM;
-    readwriteSPI(FIRMWARE_RDSR);
-    while ((readwriteSPI(0) & 0x02) == 0); // Write Enable Latch
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_FIRMWARE | SPI_CONTINUOUS;
+    spiWrite(FIRMWARE_RDSR);
+    while ((spiRead() & 0x02) == 0); // Write Enable Latch
     REG_SPICNT = 0;
 
     // Page write
-    REG_SPICNT = SPI_ENABLE | SPI_CONTINUOUS | SPI_DEVICE_NVRAM;
-    readwriteSPI(FIRMWARE_PW);
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_FIRMWARE | SPI_CONTINUOUS;
+    spiWrite(FIRMWARE_PW);
 
     // Set the address
-    readwriteSPI((address >> 16) & 0xFF);
-    readwriteSPI((address >> 8) & 0xFF);
-    readwriteSPI(address & 0xFF);
+    spiWrite((address >> 16) & 0xFF);
+    spiWrite((address >> 8) & 0xFF);
+    spiWrite(address & 0xFF);
 
     for (int i = 0; i < 256; i++)
-        readwriteSPI(buffer[i]);
+        spiWrite(buffer[i]);
 
     REG_SPICNT = 0;
 
     // Wait for programming to finish
-    REG_SPICNT = SPI_ENABLE | SPI_CONTINUOUS | SPI_DEVICE_NVRAM;
-    readwriteSPI(FIRMWARE_RDSR);
-    while (readwriteSPI(0) & 0x01); // Write In Progress
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_FIRMWARE | SPI_CONTINUOUS;
+    spiWrite(FIRMWARE_RDSR);
+    while (spiRead() & 0x01); // Write In Progress
     REG_SPICNT = 0;
 
     leaveCriticalSection(oldIME);

--- a/source/arm7/input.c
+++ b/source/arm7/input.c
@@ -29,8 +29,6 @@ void inputGetAndSend(void)
 
     u16 keys = REG_KEYXY;
 
-    // touchPenDown() handles DSi-mode touch detection
-    // (on DS mode, it just checks REG_KEYXY & KEYXY_TOUCH)
     if (touchPenDown())
     {
         touchReadXY(&tempPos);

--- a/source/arm7/input.c
+++ b/source/arm7/input.c
@@ -24,15 +24,15 @@
 
 // The number of frames to debounce/hold pen presses for.
 // Set to 0 to disable.
-#define PEN_DOWN_DEBOUNCE 2
+#define PEN_DOWN_DEBOUNCE 1
 // The shift (1 << N) used for the IIR filter to average noisy samples across
 // time. Set to 0 to disable.
-#define TOUCH_MAX_NOISE_PEN_UP_IIR_SHIFT 6
+#define TOUCH_MAX_NOISE_PEN_UP_IIR_SHIFT 5
 
 // The maximum value of noisiness for pressing a pen down (measurement now valid).
 #define TOUCH_MAX_NOISE_PEN_DOWN 38
 // The minimum value of noisiness for lifting a pen up (measurement no longer valid).
-#define TOUCH_MAX_NOISE_PEN_UP   76
+#define TOUCH_MAX_NOISE_PEN_UP   50
 
 // === Touchscreen filter ===
 

--- a/source/arm7/input.c
+++ b/source/arm7/input.c
@@ -3,7 +3,10 @@
 //
 // Copyright (C) 2008-2010 Dave Murphy (WinterMute)
 // Copyright (C) 2008 Jason Rogers (Dovoto)
+// Copyright (C) 2024 Adrian "asie" Siekierka
 
+#include "nds/input.h"
+#include "arm7/libnds_internal.h"
 #include <nds/arm7/input.h>
 #include <nds/arm7/serial.h>
 #include <nds/arm7/touch.h>
@@ -14,6 +17,127 @@
 #include <nds/system.h>
 #include <nds/touch.h>
 
+// === Touchscreen filter configuration ===
+
+// Replace Z1/Z2 values with X/Y noisiness measurements.
+// #define TOUCH_DEBUG_NOISINESS
+
+// The number of frames to debounce/hold pen presses for.
+// Set to 0 to disable.
+#define PEN_DOWN_DEBOUNCE 2
+// The shift (1 << N) used for the IIR filter to average noisy samples across
+// time. Set to 0 to disable.
+#define TOUCH_MAX_NOISE_PEN_UP_IIR_SHIFT 6
+
+// The maximum value of noisiness for pressing a pen down (measurement now valid).
+#define TOUCH_MAX_NOISE_PEN_DOWN 38
+// The minimum value of noisiness for lifting a pen up (measurement no longer valid).
+#define TOUCH_MAX_NOISE_PEN_UP   76
+
+// === Touchscreen filter ===
+
+// IIR filter constants.
+#define TOUCH_MAX_NOISE_PEN_UP_IIR_RATIO (1 << TOUCH_MAX_NOISE_PEN_UP_IIR_SHIFT)
+#define TOUCH_MAX_NOISE_PEN_UP_IIR_MIN (TOUCH_MAX_NOISE_PEN_UP - TOUCH_MAX_NOISE_PEN_UP_IIR_RATIO)
+
+static u16 inputTouchUpdate(touchPosition *tempPos)
+{
+#if PEN_DOWN_DEBOUNCE > 0
+    static touchPosition lastTouchPosition;
+    static bool lastPenDown = false;
+    static u8 penDownDebounce = 0;
+#else
+    touchPosition lastTouchPosition;
+    bool lastPenDown = false;
+#endif
+
+    bool penDown = touchPenDown();
+    if (penDown)
+    {
+        // Measure new touch position.
+        touchRawArray data;
+        touchReadData(&data);
+
+        penDown = false;
+        libnds_touchMeasurementFilterResult rawXresult = libnds_touchMeasurementFilter(data.rawX);
+        if (!rawXresult.value) goto noPenDown;
+        libnds_touchMeasurementFilterResult rawYresult = libnds_touchMeasurementFilter(data.rawY);
+        if (!rawYresult.value) goto noPenDown;
+
+        // Valid sample read.
+        u16 noisiness = rawXresult.noisiness > rawYresult.noisiness ? rawXresult.noisiness : rawYresult.noisiness;
+        if (noisiness <= (lastPenDown ? TOUCH_MAX_NOISE_PEN_UP : TOUCH_MAX_NOISE_PEN_DOWN))
+        {
+            lastTouchPosition.z1 = libnds_touchMeasurementFilter(data.z1).value;
+            lastTouchPosition.z2 = libnds_touchMeasurementFilter(data.z2).value;
+
+#if TOUCH_MAX_NOISE_PEN_UP_IIR_SHIFT > 0
+            // Apply an IIR filter on noisy X/Y samples.
+            // Skip the IIR filter if the pen was just pressed.
+            int n = (noisiness - TOUCH_MAX_NOISE_PEN_UP_IIR_MIN);
+            if (noisiness <= 0 || !lastPenDown)
+            {
+                lastTouchPosition.rawx = rawXresult.value;
+                lastTouchPosition.rawy = rawYresult.value;
+            }
+            else if (noisiness <= TOUCH_MAX_NOISE_PEN_UP_IIR_RATIO)
+            {
+                lastTouchPosition.rawx =
+                    ((rawXresult.value * (TOUCH_MAX_NOISE_PEN_UP_IIR_RATIO - n))
+                    + (lastTouchPosition.rawx * n)) >> TOUCH_MAX_NOISE_PEN_UP_IIR_SHIFT;
+                lastTouchPosition.rawy =
+                    ((rawYresult.value * (TOUCH_MAX_NOISE_PEN_UP_IIR_RATIO - n))
+                    + (lastTouchPosition.rawy * n)) >> TOUCH_MAX_NOISE_PEN_UP_IIR_SHIFT;
+            }
+#else
+            lastTouchPosition.rawx = rawXresult.value;
+            lastTouchPosition.rawy = rawYresult.value;
+#endif
+
+            touchApplyCalibration(lastTouchPosition.rawx, lastTouchPosition.rawy, &lastTouchPosition.px, &lastTouchPosition.py);
+            penDown = true;
+        }
+
+#ifdef TOUCH_DEBUG_NOISINESS
+        lastTouchPosition.z1 = rawXresult.noisiness;
+        lastTouchPosition.z2 = rawYresult.noisiness;
+#endif
+    }
+
+noPenDown:
+#if PEN_DOWN_DEBOUNCE > 0
+    // Perform simple debouncing.
+    // Hold new presses for PEN_DOWN_DEBOUNCE frames.
+    if (!penDownDebounce)
+    {
+        if (lastPenDown != penDown)
+        {
+            lastPenDown = penDown;
+            if (penDown)
+                penDownDebounce = PEN_DOWN_DEBOUNCE;
+        }
+    }
+    else penDownDebounce--;
+#else
+    lastPenDown = penDown;
+#endif
+
+    // Return the touch position and key mask.
+    if (lastPenDown)
+    {
+        *tempPos = lastTouchPosition;
+        return 0;
+    }
+    else
+    {
+        return KEYXY_TOUCH;
+    }
+}
+
+// === Input updates ===
+
+// Sleep if lid has been closed for a specified number of frames
+
 static u16 sleepCounter = 0;
 static u16 sleepCounterMax = 20;
 
@@ -22,36 +146,8 @@ void inputSetLidSleepDuration(u16 frames)
     sleepCounterMax = frames;
 }
 
-void inputGetAndSend(void)
+static void inputSleepUpdate(u16 keys)
 {
-    touchPosition tempPos = {0};
-    FifoMessage msg = {0};
-
-    u16 keys = REG_KEYXY;
-
-    if (touchPenDown())
-    {
-        touchReadXY(&tempPos);
-
-        // Only mark pen as down if the coordinates are valid
-        if (tempPos.rawx && tempPos.rawy)
-        {
-            msg.SystemInput.touch = tempPos;
-            keys &= ~KEYXY_TOUCH;
-        }
-        else
-        {
-            keys |= KEYXY_TOUCH;
-        }
-    }
-    else
-    {
-        keys |= KEYXY_TOUCH;
-    }
-
-    msg.SystemInput.keys = keys;
-
-    // Sleep if lid has been closed for a specified number of frames
     if (sleepCounterMax > 0)
     {
         if (keys & KEYXY_LID)
@@ -65,7 +161,17 @@ void inputGetAndSend(void)
             sleepCounter = 0;
         }
     }
+}
 
+void inputGetAndSend(void)
+{
+    FifoMessage msg = {0};
+
+    u16 keys = REG_KEYXY & ~KEYXY_TOUCH;
+    keys |= inputTouchUpdate(&msg.SystemInput.touch);
+    inputSleepUpdate(keys);
+
+    msg.SystemInput.keys = keys;
     msg.type = SYS_INPUT_MESSAGE;
     fifoSendDatamsg(FIFO_SYSTEM, sizeof(msg), (u8 *)&msg);
 }

--- a/source/arm7/libnds_internal.h
+++ b/source/arm7/libnds_internal.h
@@ -11,4 +11,26 @@ void storageMsgHandler(int bytes, void *user_data);
 void storageValueHandler(u32 value, void *user_data);
 void firmwareMsgHandler(int bytes, void *user_data);
 
+#define LIBNDS_TOUCH_INVALID 0xFFFF
+
+/**
+ * @brief Maximum difference used for pixel readouts.
+ * 
+ * 2.5 pixels * 16 = 40.
+ * Use a slightly smaller range as calibration is usually confined to a smaller window than the full 4096.
+ */
+#define LIBNDS_TOUCH_MAX_DIFF_PIXEL 38
+
+/**
+ * @brief Maximum difference used for other readouts.
+ *
+ * No particular restriction.
+ */
+#define LIBNDS_TOUCH_MAX_DIFF_OTHER 0xFFFFFF
+
+/**
+ * @brief Perform touch filtering on the raw measurements provided.
+ */
+u16 libnds_touchFilter(u16 *measurements, int max_diff);
+
 #endif // ARM7_LIBNDS_INTERNAL_H__

--- a/source/arm7/libnds_internal.h
+++ b/source/arm7/libnds_internal.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Zlib
 //
 // Copyright (c) 2023 Antonio Niño Díaz
+// Copyright (c) 2024 Adrian "asie" Siekierka
 
 #ifndef ARM7_LIBNDS_INTERNAL_H__
 #define ARM7_LIBNDS_INTERNAL_H__
@@ -11,26 +12,17 @@ void storageMsgHandler(int bytes, void *user_data);
 void storageValueHandler(u32 value, void *user_data);
 void firmwareMsgHandler(int bytes, void *user_data);
 
-#define LIBNDS_TOUCH_INVALID 0xFFFF
+typedef struct {
+    u16 value;      // 1..4095, 0 if invalid
+    u16 noisiness;  // 0..4095, ~15-16 = 1 pixel
+} libnds_touchMeasurementFilterResult;
 
 /**
- * @brief Maximum difference used for pixel readouts.
- * 
- * 2.5 pixels * 16 = 40.
- * Use a slightly smaller range as calibration is usually confined to a smaller window than the full 4096.
- */
-#define LIBNDS_TOUCH_MAX_DIFF_PIXEL 38
-
-/**
- * @brief Maximum difference used for other readouts.
+ * @brief Perform filtering on the raw touch samples provided to return one
+ * averaged sample and an estimate of how noisy it is, while skipping outliers.
  *
- * No particular restriction.
+ * Internal. See touchFilter.c for more information.
  */
-#define LIBNDS_TOUCH_MAX_DIFF_OTHER 0xFFFFFF
-
-/**
- * @brief Perform touch filtering on the raw measurements provided.
- */
-u16 libnds_touchFilter(u16 *measurements, int max_diff);
+libnds_touchMeasurementFilterResult libnds_touchMeasurementFilter(u16 values[5]);
 
 #endif // ARM7_LIBNDS_INTERNAL_H__

--- a/source/arm7/microphone.c
+++ b/source/arm7/microphone.c
@@ -6,6 +6,9 @@
 // Copyright (C) 2005 Dave Murphy (WinterMute)
 // Copyright (C) 2005 Chris Double (doublec)
 
+#include "nds/arm7/serial.h"
+#include "nds/arm7/tsc.h"
+#include "nds/system.h"
 #include <nds/arm7/audio.h>
 #include <nds/arm7/codec.h>
 #include <nds/fifocommon.h>
@@ -24,81 +27,29 @@ s16 micReadData16_TWL(void);
 // Turn on the Microphone Amp. Code based on neimod's example.
 void micSetAmp_NTR(u8 control, u8 gain)
 {
-    SerialWaitBusy();
+    spiWaitBusy();
 
-    REG_SPICNT = SPI_ENABLE | SPI_DEVICE_POWER | SPI_BAUD_1MHz | SPI_CONTINUOUS;
-    REG_SPIDATA = PM_AMP_OFFSET;
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_POWER | SPI_CONTINUOUS;
+    spiWrite(PM_AMP_OFFSET);
 
-    SerialWaitBusy();
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_POWER;
+    spiWrite(control);
 
-    REG_SPICNT = SPI_ENABLE | SPI_DEVICE_POWER | SPI_BAUD_1MHz;
-    REG_SPIDATA = control;
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_POWER | SPI_CONTINUOUS;
+    spiWrite(PM_GAIN_OFFSET);
 
-    SerialWaitBusy();
-
-    REG_SPICNT = SPI_ENABLE | SPI_DEVICE_POWER | SPI_BAUD_1MHz | SPI_CONTINUOUS;
-    REG_SPIDATA = PM_GAIN_OFFSET;
-
-    SerialWaitBusy();
-
-    REG_SPICNT = SPI_ENABLE | SPI_DEVICE_POWER | SPI_BAUD_1MHz;
-    REG_SPIDATA = gain;
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_POWER;
+    spiWrite(gain);
 }
 
-// Read a byte from the microphone. Code based on neimod's example.
-u8 micReadData8_NTR(void)
+static inline u8 micReadData8_NTR(void)
 {
-    u16 result, result2;
-
-    SerialWaitBusy();
-
-    REG_SPICNT = SPI_ENABLE | SPI_DEVICE_MICROPHONE | SPI_BAUD_2MHz | SPI_CONTINUOUS;
-    REG_SPIDATA = 0xEC;  // Touchscreen command format for AUX
-
-    SerialWaitBusy();
-
-    REG_SPIDATA = 0x00;
-
-    SerialWaitBusy();
-
-    result = REG_SPIDATA;
-
-    REG_SPICNT = SPI_ENABLE | SPI_DEVICE_TOUCH | SPI_BAUD_2MHz;
-    REG_SPIDATA = 0x00;
-
-    SerialWaitBusy();
-
-    result2 = REG_SPIDATA;
-
-    return (((result & 0x7F) << 1) | ((result2 >> 7) & 1));
+    return tscRead(TSC_MEASURE_AUX | TSC_CONVERT_8BIT) >> 4;
 }
 
-// Read a short from the microphone. Code based on neimod's example.
-u16 micReadData12_NTR(void)
+static inline u16 micReadData12_NTR(void)
 {
-    u16 result, result2;
-
-    SerialWaitBusy();
-
-    REG_SPICNT = SPI_ENABLE | SPI_DEVICE_MICROPHONE | SPI_BAUD_2MHz | SPI_CONTINUOUS;
-    REG_SPIDATA = 0xE4; // Touchscreen command format for AUX, 12bit
-
-    SerialWaitBusy();
-
-    REG_SPIDATA = 0x00;
-
-    SerialWaitBusy();
-
-    result = REG_SPIDATA;
-
-    REG_SPICNT = SPI_ENABLE | SPI_DEVICE_TOUCH | SPI_BAUD_2MHz;
-    REG_SPIDATA = 0x00;
-
-    SerialWaitBusy();
-
-    result2 = REG_SPIDATA;
-
-    return (((result & 0x7F) << 5) | ((result2 >> 3) & 0x1F));
+    return tscRead(TSC_MEASURE_AUX | TSC_CONVERT_12BIT);
 }
 
 void micSetAmp(u8 control, u8 gain)

--- a/source/arm7/microphone.c
+++ b/source/arm7/microphone.c
@@ -44,12 +44,12 @@ void micSetAmp_NTR(u8 control, u8 gain)
 
 static inline u8 micReadData8_NTR(void)
 {
-    return tscRead(TSC_MEASURE_AUX | TSC_CONVERT_8BIT) >> 4;
+    return tscRead(TSC_MEASURE_AUX | TSC_CONVERT_8BIT | TSC_POWER_AUTO) >> 4;
 }
 
 static inline u16 micReadData12_NTR(void)
 {
-    return tscRead(TSC_MEASURE_AUX | TSC_CONVERT_12BIT);
+    return tscRead(TSC_MEASURE_AUX | TSC_CONVERT_12BIT | TSC_POWER_AUTO);
 }
 
 void micSetAmp(u8 control, u8 gain)

--- a/source/arm7/touch.c
+++ b/source/arm7/touch.c
@@ -20,132 +20,23 @@
 
 #include "libnds_internal.h"
 
-// This touch filter focuses on removing outlier inputs and reducing noise while
-// preserving responsiveness.
-//
-// Five given inputs are sorted. Of those, the three closest values fitting within
-// the provided range are selected, with a small preference for the midpoint. Of
-// those, an average is calculated.
-//
-// This should ensure a consistent readout if >=60% low-noise, valid inputs can be
-// identified, even if the inputs are biased in a specific direction.
-//
-// See also:
-//
-// - https://dlbeer.co.nz/articles/tsf.html (median, IIR)
-// - https://www.ti.com/lit/an/sbaa155a/sbaa155a.pdf (average, weighted average, median)
-// - https://www.ti.com/lit/an/slyt209a/slyt209a.pdf (average with out-of-range rejection)
-
-// Compare and swap two values.
-static inline void compare_and_swap(u16 *a, u16 *b)
-{
-    u16 tmp;
-
-    if (*a > *b)
-    {
-        tmp = *a;
-        *a = *b;
-        *b = tmp;
-    }
-}
-
-// Compare two outliers; used internally in libnds_touchFilter.
-#define LIBNDS_TOUCH_DIFF_OUTLIERS(a, b) \
-    tmp_diff = abs(values[b] - values[a]); \
-    if (!tmp_diff) goto location_found; \
-    else if (tmp_diff < diff) { \
-        v = values + a; \
-        diff = tmp_diff; \
-    }
-
-u16 libnds_touchFilter(u16 *values, int max_diff)
-{
-    // Sort using a pre-calculated sorting network.
-    // This allows us to quickly check ranges and remove outliers.
-    compare_and_swap(&values[0], &values[3]);
-    compare_and_swap(&values[1], &values[4]);
-    compare_and_swap(&values[0], &values[2]);
-    compare_and_swap(&values[1], &values[3]);
-    compare_and_swap(&values[0], &values[1]);
-    compare_and_swap(&values[2], &values[4]);
-    compare_and_swap(&values[1], &values[2]);
-    compare_and_swap(&values[3], &values[4]);
-    compare_and_swap(&values[2], &values[3]);
-
-    // Find three closest values which are within the specified range.
-    // These are the most likely to be the correct read. Prefer the midpoint values.
-    u16 *v = values;
-    int diff = max_diff + 1;
-    int tmp_diff;
-    LIBNDS_TOUCH_DIFF_OUTLIERS(1, 3);
-    LIBNDS_TOUCH_DIFF_OUTLIERS(0, 2);
-    LIBNDS_TOUCH_DIFF_OUTLIERS(2, 4);
-
-    // If no such triplet exists, return an invalid read.
-    if (diff > max_diff)
-        return 0;
-
-location_found:
-    ;
-    // Calculate a slightly weighted average; this saves a division.
-    u32 value = (((v[0] + v[2]) * 5) + (v[1] * 6)) >> 4;
-    // Skip value 0 when returning - libnds assumes it to be an invalid position.
-    return value ? value : 1;
-}
-
-u32 touchReadTemperature(int *t1, int *t2)
-{
-    *t1 = tscRead(TSC_MEASURE_TEMP1 | TSC_POWER_ON);
-    *t2 = tscRead(TSC_MEASURE_TEMP2 | TSC_POWER_AUTO);
-    return 8490 * (*t2 - *t1) - 273 * 4096;
-}
-
-static void touchReadDSMode(touchPosition *touchPos)
-{
-    u16 values[4][6];
-
-    int oldIME = enterCriticalSection();
-
-    // Hold ADC on. We're reading at near-full speed, and this
-    // may slightly improve read accuracy.
-    tscMeasure(TSC_MEASURE_Z1 | TSC_POWER_ON, values[0], 6);
-    tscMeasure(TSC_MEASURE_Z2 | TSC_POWER_ON, values[1], 6);
-    tscMeasure(TSC_MEASURE_X | TSC_POWER_ON, values[2], 6);
-    tscMeasure(TSC_MEASURE_Y | TSC_POWER_ON, values[3], 6);
-
-    // Make an empty read to switch the TSC into power-down mode.
-    tscRead(TSC_MEASURE_TEMP1 | TSC_POWER_AUTO);
-
-    leaveCriticalSection(oldIME);
-
-    // Skip the first value in each readout.
-    touchPos->z1 = libnds_touchFilter(values[0] + 1, LIBNDS_TOUCH_MAX_DIFF_OTHER);
-    touchPos->z2 = libnds_touchFilter(values[1] + 1, LIBNDS_TOUCH_MAX_DIFF_OTHER);
-    touchPos->rawx = libnds_touchFilter(values[2] + 1, LIBNDS_TOUCH_MAX_DIFF_PIXEL);
-    touchPos->rawy = libnds_touchFilter(values[3] + 1, LIBNDS_TOUCH_MAX_DIFF_PIXEL);
-
-    if (!touchPos->z1) touchPos->z2 = 0;
-    else if (!touchPos->z2) touchPos->z1 = 0;
-
-    if (!touchPos->rawx) touchPos->rawy = 0;
-    else if (!touchPos->rawy) touchPos->rawx = 0;
-}
-
 static s32 xscale, yscale;
 static s32 xoffset, yoffset;
 
+#define TOUCH_CAL_SHIFT 19
+
 void touchInit(void)
 {
-    xscale = ((PersonalData->calX2px - PersonalData->calX1px) << 19)
+    xscale = ((PersonalData->calX2px - PersonalData->calX1px) << TOUCH_CAL_SHIFT)
              / ((PersonalData->calX2) - (PersonalData->calX1));
-    yscale = ((PersonalData->calY2px - PersonalData->calY1px) << 19)
+    yscale = ((PersonalData->calY2px - PersonalData->calY1px) << TOUCH_CAL_SHIFT)
              / ((PersonalData->calY2) - (PersonalData->calY1));
 
     xoffset = ((PersonalData->calX1 + PersonalData->calX2) * xscale
-               - ((PersonalData->calX1px + PersonalData->calX2px) << 19))
+               - ((PersonalData->calX1px + PersonalData->calX2px) << TOUCH_CAL_SHIFT))
               / 2;
     yoffset = ((PersonalData->calY1 + PersonalData->calY2) * yscale
-               - ((PersonalData->calY1px + PersonalData->calY2px) << 19))
+               - ((PersonalData->calY1px + PersonalData->calY2px) << TOUCH_CAL_SHIFT))
               / 2;
 
     if (cdcIsAvailable())
@@ -156,26 +47,57 @@ void touchInit(void)
     }
 }
 
+void touchApplyCalibration(u16 rawx, u16 rawy, u16 *tpx, u16 *tpy)
+{
+    s16 px = (rawx * xscale - xoffset + xscale / 2) >> TOUCH_CAL_SHIFT;
+    s16 py = (rawy * yscale - yoffset + yscale / 2) >> TOUCH_CAL_SHIFT;
+
+    if (px < 0)
+        px = 0;
+    else if (px > (SCREEN_WIDTH - 1))
+        px = SCREEN_WIDTH - 1;
+
+    if (py < 0)
+        py = 0;
+    else if (py > (SCREEN_HEIGHT - 1))
+        py = SCREEN_HEIGHT - 1;
+
+    *tpx = px;
+    *tpy = py;
+}
+
 bool touchPenDown(void)
 {
-    bool down;
-    int oldIME = enterCriticalSection();
-
     if (cdcIsAvailable())
-        down = cdcTouchPenDown();
+    {
+        int oldIME = enterCriticalSection();
+        bool down = cdcTouchPenDown();
+        leaveCriticalSection(oldIME);
+        return down;
+    }
     else
-        down = !(REG_KEYXY & KEYXY_TOUCH);
+    {
+        return tscTouchPenDown();
+    }
+}
 
-    leaveCriticalSection(oldIME);
-    return down;
+void touchReadData(touchRawArray *data)
+{
+    if (cdcIsAvailable())
+        cdcTouchReadData(data);
+    else
+        tscTouchReadData(data);
 }
 
 void touchReadXY(touchPosition *touchPos)
 {
-    if (cdcIsAvailable())
-        cdcTouchRead(touchPos);
-    else
-        touchReadDSMode(touchPos);
+    touchRawArray data;
+    touchReadData(&data);
+
+    touchPos->rawx = libnds_touchMeasurementFilter(data.rawX).value;
+    touchPos->rawy = libnds_touchMeasurementFilter(data.rawY).value;
+    touchPos->z1 = libnds_touchMeasurementFilter(data.z1).value;
+    touchPos->z2 = libnds_touchMeasurementFilter(data.z2).value;
 
     if (!touchPos->rawx)
     {
@@ -184,18 +106,5 @@ void touchReadXY(touchPosition *touchPos)
         return;
     }
 
-    s16 px = (touchPos->rawx * xscale - xoffset + xscale / 2) >> 19;
-    s16 py = (touchPos->rawy * yscale - yoffset + yscale / 2) >> 19;
-
-    if (px < 0)
-        px = 0;
-    if (py < 0)
-        py = 0;
-    if (px > (SCREEN_WIDTH - 1))
-        px = SCREEN_WIDTH - 1;
-    if (py > (SCREEN_HEIGHT - 1))
-        py = SCREEN_HEIGHT - 1;
-
-    touchPos->px = px;
-    touchPos->py = py;
+    touchApplyCalibration(touchPos->rawx, touchPos->rawy, &touchPos->px, &touchPos->py);
 }

--- a/source/arm7/touchFilter.c
+++ b/source/arm7/touchFilter.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2024 Adrian "asie" Siekierka
+
+// Touch screen filtering for the ARM7
+
+#include <nds/arm7/codec.h>
+#include <nds/arm7/input.h>
+#include <nds/arm7/touch.h>
+#include <nds/arm7/tsc.h>
+#include <nds/interrupts.h>
+#include <nds/ndstypes.h>
+#include <nds/system.h>
+
+#include "libnds_internal.h"
+
+// This touch filter focuses on removing outlier inputs and reducing noise while
+// preserving responsiveness.
+//
+// Five given inputs are sorted. Of those, the three closest values fitting within
+// the provided range are selected, with a small preference for the midpoint. Of
+// those, an average is calculated.
+//
+// This should ensure a consistent readout if >=60% low-noise, valid inputs can be
+// identified, even if the inputs are biased in a specific direction.
+//
+// See also:
+//
+// - https://dlbeer.co.nz/articles/tsf.html (median, IIR)
+// - https://www.ti.com/lit/an/sbaa155a/sbaa155a.pdf (average, weighted average, median)
+// - https://www.ti.com/lit/an/slyt209a/slyt209a.pdf (average with out-of-range rejection)
+
+// Compare and swap two values.
+static inline void compare_and_swap(u16 *a, u16 *b)
+{
+    u16 tmp;
+
+    if (*a > *b)
+    {
+        tmp = *a;
+        *a = *b;
+        *b = tmp;
+    }
+}
+
+// Compare two outliers; used internally in libnds_touchMeasurementFilter.
+#define LIBNDS_TOUCH_DIFF_OUTLIERS(a, b) \
+    tmp_noise = values[b] - values[a]; \
+    if (tmp_noise < result.noisiness) { \
+        v = values + a; \
+        result.noisiness = tmp_noise; \
+        if (!tmp_noise) goto location_found; \
+    }
+
+libnds_touchMeasurementFilterResult libnds_touchMeasurementFilter(u16 values[5])
+{
+    libnds_touchMeasurementFilterResult result = {0, 0xFFFF};
+
+    // Sort using a pre-calculated sorting network.
+    // This allows us to quickly check ranges and remove outliers.
+    compare_and_swap(&values[0], &values[3]);
+    compare_and_swap(&values[1], &values[4]);
+    compare_and_swap(&values[0], &values[2]);
+    compare_and_swap(&values[1], &values[3]);
+    compare_and_swap(&values[0], &values[1]);
+    compare_and_swap(&values[2], &values[4]);
+    compare_and_swap(&values[1], &values[2]);
+    compare_and_swap(&values[3], &values[4]);
+    compare_and_swap(&values[2], &values[3]);
+
+    // Find three closest values which are within the specified range.
+    // These are the most likely to be the correct read. Prefer the midpoint values.
+    u16 *v = values;
+    s32 tmp_noise;
+    LIBNDS_TOUCH_DIFF_OUTLIERS(1, 3);
+    LIBNDS_TOUCH_DIFF_OUTLIERS(0, 2);
+    LIBNDS_TOUCH_DIFF_OUTLIERS(2, 4);
+
+location_found:
+    ;
+    // Calculate a slightly weighted average; this saves a division.
+    u16 value = (((v[0] + v[2]) * 5) + (v[1] * 6)) >> 4;
+    // Skip value 0 when returning - libnds assumes it to be an invalid position.
+    result.value = value ? value : 1;
+    return result;
+}

--- a/source/arm7/touchFilter.c
+++ b/source/arm7/touchFilter.c
@@ -79,7 +79,8 @@ libnds_touchMeasurementFilterResult libnds_touchMeasurementFilter(u16 values[5])
 location_found:
     ;
     // Calculate a slightly weighted average; this saves a division.
-    u16 value = (((v[0] + v[2]) * 5) + (v[1] * 6)) >> 4;
+    // (v[0] * 5 + v[1] * 6 + v[2] * 5) / 16
+    u16 value = (((v[0] + v[1] + v[2]) * 5) + v[1]) >> 4;
     // Skip value 0 when returning - libnds assumes it to be an invalid position.
     result.value = value ? value : 1;
     return result;

--- a/source/arm7/tsc.c
+++ b/source/arm7/tsc.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2024 Adrian "asie" Siekierka
+
+#include <nds/arm7/tsc.h>
+#include <nds/interrupts.h>
+#include <nds/ndstypes.h>
+#include <nds/system.h>
+
+uint16_t tscRead(uint32_t command)
+{
+    uint8_t msb, lsb;
+    uint32_t oldIME = enterCriticalSection();
+
+    spiWaitBusy();
+
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC | SPI_CONTINUOUS;
+    spiWrite(command);
+
+    msb = spiRead() & 0x7F;
+
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC;
+    lsb = spiRead() & 0xF8;
+
+    leaveCriticalSection(oldIME);
+
+    return (msb << 5) | (lsb >> 3);
+}
+
+// Perform a 16 clocks-per-conversion measurement.
+void tscMeasure(uint32_t command, uint16_t *buffer, uint32_t count)
+{
+    if (!count) return;
+
+    uint8_t msb, lsb;
+    uint32_t oldIME = enterCriticalSection();
+
+    spiWaitBusy();
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC | SPI_CONTINUOUS;
+
+    spiWrite(command);
+
+    // First .. second-to-last measurement
+    while (--count)
+    {
+        msb = spiRead() & 0x7F;
+        lsb = spiExchange(command) & 0xF8;
+
+        *(buffer++) = (msb << 5) | (lsb >> 3);
+    }
+
+    // Last measurement
+    msb = spiRead() & 0x7F;
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC;
+    lsb = spiRead() & 0xF8;
+
+    leaveCriticalSection(oldIME);
+
+    *(buffer++) = (msb << 5) | (lsb >> 3);
+}

--- a/source/arm7/tsc.c
+++ b/source/arm7/tsc.c
@@ -8,7 +8,6 @@
 #include <nds/ndstypes.h>
 #include <nds/system.h>
 
-#define TSC_MASK_12BIT (0xFFF << 3)
 
 // Internal. Read TSC data to buffer, excluding the first SPI write.
 // No IRQ protection.
@@ -22,7 +21,7 @@ static void __tscReadToBuffer(u32 command, u16 *buffer, u32 count)
         msb = spiRead();
         lsb = spiExchange(command);
 
-        *(buffer++) = ((msb << 5) | (lsb >> 3)) & TSC_MASK_12BIT;
+        *(buffer++) = ((msb << 5) | (lsb >> 3)) & 0xFFF;
     }
 
     // Last measurement
@@ -30,7 +29,7 @@ static void __tscReadToBuffer(u32 command, u16 *buffer, u32 count)
     REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC;
     lsb = spiRead();
 
-    *(buffer++) = ((msb << 5) | (lsb >> 3)) & TSC_MASK_12BIT;
+    *(buffer++) = ((msb << 5) | (lsb >> 3)) & 0xFFF;
 }
 
 // Internal. Read five measurements from TSC, skipping the first.
@@ -63,7 +62,7 @@ u16 tscRead(u32 command)
 
     leaveCriticalSection(oldIME);
 
-    return ((msb << 5) | (lsb >> 3)) & TSC_MASK_12BIT;
+    return ((msb << 5) | (lsb >> 3)) & 0xFFF;
 }
 
 // Perform a 16 clocks-per-conversion measurement.

--- a/source/arm7/tsc.c
+++ b/source/arm7/tsc.c
@@ -2,59 +2,140 @@
 //
 // Copyright (C) 2024 Adrian "asie" Siekierka
 
+#include "nds/arm7/touch.h"
 #include <nds/arm7/tsc.h>
 #include <nds/interrupts.h>
 #include <nds/ndstypes.h>
 #include <nds/system.h>
 
-uint16_t tscRead(uint32_t command)
+#define TSC_MASK_12BIT (0xFFF << 3)
+
+// Internal. Read TSC data to buffer, excluding the first SPI write.
+// No IRQ protection.
+static void __tscReadToBuffer(u32 command, u16 *buffer, u32 count)
 {
-    uint8_t msb, lsb;
-    uint32_t oldIME = enterCriticalSection();
-
-    spiWaitBusy();
-
-    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC | SPI_CONTINUOUS;
-    spiWrite(command);
-
-    msb = spiRead() & 0x7F;
-
-    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC;
-    lsb = spiRead() & 0xF8;
-
-    leaveCriticalSection(oldIME);
-
-    return (msb << 5) | (lsb >> 3);
-}
-
-// Perform a 16 clocks-per-conversion measurement.
-void tscMeasure(uint32_t command, uint16_t *buffer, uint32_t count)
-{
-    if (!count) return;
-
-    uint8_t msb, lsb;
-    uint32_t oldIME = enterCriticalSection();
-
-    spiWaitBusy();
-    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC | SPI_CONTINUOUS;
-
-    spiWrite(command);
+    u8 msb, lsb;
 
     // First .. second-to-last measurement
     while (--count)
     {
-        msb = spiRead() & 0x7F;
-        lsb = spiExchange(command) & 0xF8;
+        msb = spiRead();
+        lsb = spiExchange(command);
 
-        *(buffer++) = (msb << 5) | (lsb >> 3);
+        *(buffer++) = ((msb << 5) | (lsb >> 3)) & TSC_MASK_12BIT;
     }
 
     // Last measurement
-    msb = spiRead() & 0x7F;
+    msb = spiRead();
     REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC;
-    lsb = spiRead() & 0xF8;
+    lsb = spiRead();
+
+    *(buffer++) = ((msb << 5) | (lsb >> 3)) & TSC_MASK_12BIT;
+}
+
+// Internal. Read five measurements from TSC, skipping the first.
+// No IRQ protection.
+static void __tscMeasureFiveSkipFirst(u32 command, u16 *buffer)
+{
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC | SPI_CONTINUOUS;
+
+    spiWrite(command);
+    spiRead();
+    spiWrite(command);
+
+    __tscReadToBuffer(command, buffer, 5);
+}
+
+u16 tscRead(u32 command)
+{
+    uint8_t msb, lsb;
+    uint32_t oldIME = enterCriticalSection();
+
+    spiWaitBusy();
+
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC | SPI_CONTINUOUS;
+    spiWrite(command);
+
+    msb = spiRead();
+
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC;
+    lsb = spiRead();
 
     leaveCriticalSection(oldIME);
 
-    *(buffer++) = (msb << 5) | (lsb >> 3);
+    return ((msb << 5) | (lsb >> 3)) & TSC_MASK_12BIT;
+}
+
+// Perform a 16 clocks-per-conversion measurement.
+void tscMeasure(u32 command, u16 *buffer, u32 count)
+{
+    if (!count) return;
+
+    u32 oldIME = enterCriticalSection();
+
+    spiWaitBusy();
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC | SPI_CONTINUOUS;
+
+    spiWrite(command);
+
+    __tscReadToBuffer(command, buffer, count);
+
+    leaveCriticalSection(oldIME);
+}
+
+bool tscTouchReadData(touchRawArray *data)
+{
+    int oldIME = enterCriticalSection();
+
+    // Hold ADC on. We're reading at near-full speed, and this
+    // may slightly improve read accuracy.
+
+    // Skip the first sample; to achieve this, we read measurements
+    // into the *preceding* halfword for all values.
+    spiWaitBusy();
+    __tscMeasureFiveSkipFirst(TSC_MEASURE_Z1 | TSC_POWER_ON, &data->z1[0]);
+    __tscMeasureFiveSkipFirst(TSC_MEASURE_Z2 | TSC_POWER_ON, &data->z2[0]);
+    __tscMeasureFiveSkipFirst(TSC_MEASURE_X | TSC_POWER_ON, &data->rawX[0]);
+    __tscMeasureFiveSkipFirst(TSC_MEASURE_Y | TSC_POWER_ON, &data->rawY[0]);
+
+    // Make an empty read to switch the TSC into power-down mode.
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC | SPI_CONTINUOUS;
+    spiWrite(TSC_MEASURE_TEMP1 | TSC_POWER_AUTO);
+    spiRead();
+    REG_SPICNT = SPI_ENABLE | SPI_TARGET_TSC;
+    spiRead();
+
+    REG_SPICNT = 0;
+
+    leaveCriticalSection(oldIME);
+
+    return true;
+}
+
+/// The constant 273.15, expressed in 20.12 fixed point.
+#define KELVIN_CELSIUS_DIFF_20_12 1118822
+
+// Deriving the delta multiplier:
+//
+// T = ([electron charge] * [voltage delta]) / ([Boltzmann constant] * ln([voltage ratio]))
+// voltage ratio (of TEMP2 relative to TEMP1) = 91
+//
+// T = 2.573 * [voltage delta] mV
+// voltage delta (V) = (TEMP2 - TEMP1) * Vref / 4096
+// ... on NDS, Vref (V) ~= 3.3
+//
+// T = 2.573 * 3.3 / 4096 * 1000 * (TEMP2 - TEMP1)
+//
+// T = 2.073 * (TEMP2 - TEMP1)
+//
+// T (20.12) = 2.073 * 4096 * (TEMP2 - TEMP1)
+// T (20.12) = 8490 * (TEMP2 - TEMP1)
+#define TEMPERATURE_DELTA_MULTIPLIER 8490
+
+s32 tscReadTemperature(void)
+{
+    // TODO: Should some kind of noise filter be used here too?
+    u16 temp1 = tscRead(TSC_MEASURE_TEMP1 | TSC_POWER_ON);
+    u16 temp2 = tscRead(TSC_MEASURE_TEMP2 | TSC_POWER_AUTO);
+    return TEMPERATURE_DELTA_MULTIPLIER * (temp2 - temp1) - KELVIN_CELSIUS_DIFF_20_12;
 }

--- a/source/arm7/userSettings.c
+++ b/source/arm7/userSettings.c
@@ -3,9 +3,8 @@
 //
 // Copyright (C) 2005 Dave Murphy (WinterMute)
 
-#include <string.h>
-
-#include <nds/arm7/serial.h>
+#include <nds/arm7/firmware.h>
+#include <nds/bios.h>
 #include <nds/system.h>
 
 bool readUserSettings(void)


### PR DESCRIPTION
- Rewrote touch code.
  - A shared, from-scratch measurement filtering routine is now used for both TSC (NTR) and CDC (TWL) touch inputs.
  - On TSC, tscMeasure() uses the 16-clock-per-conversion method to speed up measurement readouts.
  - On both TSC and CDC, critical section code has been reduced to exclude post-measurement filtering, improving ARM7 responsiveness.
- Added helper SPI_TARGET defines and spiRead, spiWrite, spiExchange functions to clean up SPI communication code.
  - Renamed SerialWaitBusy to spiWaitBusy to match.
- Cleaned up microphone input code to use tscRead().
- Various header cleanups:
  - Firmware flash commands have been documented in firmware.h, which was split out from serial.h.
  - NTR touch screen controller commands have been documented in tsc.h, which was split out from touch.h.
  - RTC_CR has been renamed to REG_RTCCNT.
  - RTC bus control CS/SCK/IO defines have been moved from internal to public code.
  - serial.h has been split out into firmware.h.
  - touch.h has been split out into tsc.h.

The new algorithm still needs work.