### PR TITLE
console: clean up consoleLoadFont()

### DIFF
--- a/include/nds/arm9/console.h
+++ b/include/nds/arm9/console.h
@@ -69,7 +69,6 @@ typedef struct ConsoleFont
     u8 bpp;          ///< Bits per pixel in the font graphics
     u16 asciiOffset; ///< Offset to the first valid character in the font table
     u16 numChars;    ///< Number of characters in the font graphics
-    bool convertSingleColor; ///< Convert from 1bpp font
 } ConsoleFont;
 
 /// Console structure used to store the state of a console render context.

--- a/include/nds/bios.h
+++ b/include/nds/bios.h
@@ -263,10 +263,10 @@ static inline int swiIsDebugger(void)
 /// @param destination Destination address (word aligned).
 /// @param params Pointer to an UnpackStruct.
 __attribute__((always_inline))
-static inline void swiUnpackBits(const uint8_t *source, uint32_t *destination, TUnpackStruct *params)
+static inline void swiUnpackBits(const void *source, void *destination, TUnpackStruct *params)
 {
-    register const uint8_t* r0 asm("r0") = source;
-    register uint32_t* r1 asm("r1") = destination;
+    register const void* r0 asm("r0") = source;
+    register void* r1 asm("r1") = destination;
     register const TUnpackStruct* r2 asm("r2") = params;
     asm volatile inline ("swi 0x10 << ((1f - . == 4) * -16); 1:" : "+r"(r0), "+r"(r1), "+r"(r2) :: "r3", "memory");
 }


### PR DESCRIPTION
- Remove the convertSingleColor option. This should be done by your preferred asset conversion tool, such as Grit; in addition, we migrated to a proper 1bpp font a while ago for libnds itself.
- Use BIOS bit unpack routines instead of a custom one to handle font decompression.
- Always initialize the palette when an user palette is not provided.
- Add partial support for 2bpp fonts.