### PR TITLE
decompress: move from arm9 to common

### DIFF
--- a/include/nds.h
+++ b/include/nds.h
@@ -73,12 +73,12 @@
 /// - @ref nds/arm9/teak/tlf.h "TLF format description"
 ///
 /// @section utility_api Utility
-/// - @ref nds/arm9/decompress.h "Decompression"
 /// - @ref nds/arm9/image.h "Image Manipulation"
 /// - @ref nds/arm9/grf.h "GRF file loader"
 /// - @ref nds/arm9/pcx.h "PCX file loader"
 /// - @ref nds/arm9/dynamicArray.h "General Purpose dynamic array implementation"
 /// - @ref nds/arm9/linkedlist.h "General purpose linked list implementation"
+/// - @ref nds/decompress.h "Decompression"
 /// - @ref nds/sha1.h "DSi SHA1 functions"
 ///
 /// @section peripheral_api Custom Peripherals
@@ -105,9 +105,9 @@
 ///
 /// @section debug_api Debugging
 /// - @ref nds/arm9/console.h "Debug via printf to DS screen or NO$GBA"
-/// - @ref nds/debug.h "Send message to NO$GBA"
+/// - @ref nds/arm9/exceptions.h "Exception handling"
 /// - @ref nds/arm9/sassert.h "Simple assert"
-/// - @ref nds/arm9/exceptions.h "ARM9 exception handler"
+/// - @ref nds/debug.h "Send message to NO$GBA"
 
 #ifndef LIBNDS_NDS_H__
 #define LIBNDS_NDS_H__
@@ -128,6 +128,7 @@ extern "C" {
 #include <nds/cothread.h>
 #include <nds/cpu.h>
 #include <nds/debug.h>
+#include <nds/decompress.h>
 #include <nds/dma.h>
 #include <nds/fifocommon.h>
 #include <nds/input.h>
@@ -149,7 +150,6 @@ extern "C" {
 #    include <nds/arm9/cache.h>
 #    include <nds/arm9/camera.h>
 #    include <nds/arm9/console.h>
-#    include <nds/arm9/decompress.h>
 #    include <nds/arm9/dynamicArray.h>
 #    include <nds/arm9/exceptions.h>
 #    include <nds/arm9/guitarGrip.h>

--- a/include/nds/decompress.h
+++ b/include/nds/decompress.h
@@ -3,13 +3,13 @@
 //
 // Copyright (C) 2005 Jason Rogers (dovoto)
 
-/// @file nds/arm9/decompress.h
+/// @file nds/decompress.h
 ///
 /// @brief Wraps the bios decompress functionality into something a bit easier
 /// to use.
 
-#ifndef LIBNDS_NDS_ARM9_DECOMPRESS_H__
-#define LIBNDS_NDS_ARM9_DECOMPRESS_H__
+#ifndef LIBNDS_NDS_DECOMPRESS_H__
+#define LIBNDS_NDS_DECOMPRESS_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,4 +71,4 @@ void decompressStreamStruct(const void *data, void *dst, DecompressType type,
 }
 #endif
 
-#endif // LIBNDS_NDS_ARM9_DECOMPRESS_H__
+#endif // LIBNDS_NDS_DECOMPRESS_H__

--- a/source/arm9/grf.c
+++ b/source/arm9/grf.c
@@ -7,8 +7,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <nds/arm9/decompress.h>
 #include <nds/arm9/grf.h>
+#include <nds/decompress.h>
 
 // General file structure:
 //

--- a/source/arm9/keyboard.c
+++ b/source/arm9/keyboard.c
@@ -9,10 +9,10 @@
 #include <string.h>
 
 #include <nds/arm9/background.h>
-#include <nds/arm9/decompress.h>
 #include <nds/arm9/input.h>
 #include <nds/arm9/keyboard.h>
 #include <nds/cothread.h>
+#include <nds/decompress.h>
 #include <nds/interrupts.h>
 #include <nds/ndstypes.h>
 

--- a/source/common/decompress.c
+++ b/source/common/decompress.c
@@ -5,9 +5,11 @@
 
 #include <stdlib.h>
 
-#include <nds/arm9/decompress.h>
+#ifdef ARM9
 #include <nds/arm9/sassert.h>
+#endif
 #include <nds/bios.h>
+#include <nds/decompress.h>
 
 static int decompress_get_header(uint8_t *source, uint16_t *dest, uint32_t arg)
 {
@@ -76,9 +78,9 @@ void decompressStream(const void *data, void *dst, DecompressType type,
 #ifdef ARM9
     sassert(type != LZ77 && type != RLE,
             "LZ77 and RLE do not support streaming, use Vram versions");
-#endif
 
     sassert(type != HUFF, "HUFF not supported, use decompresStreamStruct()");
+#endif
 
     TDecompressionStream decompresStream =
     {
@@ -108,10 +110,10 @@ void decompressStreamStruct(const void *data, void *dst, DecompressType type,
 #ifdef ARM9
     sassert(type != LZ77 && type != RLE,
             "LZ77 and RLE do not support streaming, use Vram versions");
-#endif
 
     sassert(ds->getSize != NULL, "getSize() callback is required");
     sassert(ds->readByte != NULL, "readByte() callback is required");
+#endif
 
     switch (type)
     {
@@ -120,8 +122,10 @@ void decompressStreamStruct(const void *data, void *dst, DecompressType type,
             break;
         case HUFF:
         {
+#ifdef ARM9
             sassert(param != NULL, "Temporary buffer required for HUFF");
             sassert(ds->readWord != NULL, "readWord() callback required for HUFF");
+#endif
 
             swiDecompressHuffman(data, dst, (uintptr_t)param, ds);
             break;


### PR DESCRIPTION
This code is applicable to ARM9 and ARM7 environments, without much in the way of anything that depends on the ARM9 CPU.