### PR TITLE
include: introduce BLOCKSDS_STRICT and <oldnames.h>

### DIFF
--- a/include/fat.h
+++ b/include/fat.h
@@ -16,6 +16,8 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+// Some software relies on MAXPATHLEN, which is provided by this header.
+#include <sys/param.h>
 
 /// This function calls fatInit() with the default cache size (5 pages = 20 KB).
 ///

--- a/include/nds.h
+++ b/include/nds.h
@@ -197,6 +197,14 @@ extern "C" {
 #    include <nds/arm7/tsc.h>
 #endif // ARM7
 
+// Only include legacy name defines if _BLOCKSDS_STRICT_ is outdated or
+// undefined. Also avoid including it in code completion environments.
+#if !defined(__CLANGD__) && !defined(__INTELLISENSE__)
+#    if _BLOCKSDS_STRICT_ < _BLOCKSDS_STRICT_CURRENT_
+#        include <nds/oldnames.h>
+#    endif
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/nds.h
+++ b/include/nds.h
@@ -197,10 +197,10 @@ extern "C" {
 #    include <nds/arm7/tsc.h>
 #endif // ARM7
 
-// Only include legacy name defines if _BLOCKSDS_STRICT_ is outdated or
+// Only include legacy name defines if BLOCKSDS_STRICT is outdated or
 // undefined. Also avoid including it in code completion environments.
 #if !defined(__CLANGD__) && !defined(__INTELLISENSE__)
-#    if _BLOCKSDS_STRICT_ < _BLOCKSDS_STRICT_CURRENT_
+#    if BLOCKSDS_STRICT < BLOCKSDS_VERSIONNUM_CURRENT
 #        include <nds/oldnames.h>
 #    endif
 #endif

--- a/include/nds/arm7/clock.h
+++ b/include/nds/arm7/clock.h
@@ -123,7 +123,7 @@ void rtcReset(void);
 void rtcTransaction(uint8_t *command, uint32_t commandLength, uint8_t *result,
                     uint32_t resultLength);
 
-#if _BLOCKSDS_STRICT_ < 10300 /* 1.3.0+ */
+#if BLOCKSDS_STRICT < 10300 /* 1.3.0+ */
 // All of the deprecated helpers are using byte arrays as input/output types
 // instead of structures.
 

--- a/include/nds/arm7/clock.h
+++ b/include/nds/arm7/clock.h
@@ -123,6 +123,7 @@ void rtcReset(void);
 void rtcTransaction(uint8_t *command, uint32_t commandLength, uint8_t *result,
                     uint32_t resultLength);
 
+#if _BLOCKSDS_STRICT_ < 10300 /* 1.3.0+ */
 // All of the deprecated helpers are using byte arrays as input/output types
 // instead of structures.
 
@@ -131,6 +132,7 @@ __attribute__((deprecated)) void rtcSetTime(uint8_t *time);
 
 __attribute__((deprecated)) void rtcGetTimeAndDate(uint8_t *time);
 __attribute__((deprecated)) void rtcSetTimeAndDate(uint8_t *time);
+#endif
 
 void BCDToInteger(uint8_t *data, uint32_t length);
 void integerToBCD(uint8_t *data, uint32_t length);

--- a/include/nds/arm7/serial.h
+++ b/include/nds/arm7/serial.h
@@ -84,7 +84,6 @@ static inline void spiWaitBusy(void)
 {
     while (REG_SPICNT & SPI_BUSY);
 }
-#define SerialWaitBusy spiWaitBusy
 
 static inline u8 spiExchange(u8 value)
 {

--- a/include/nds/arm9/console.h
+++ b/include/nds/arm9/console.h
@@ -56,11 +56,6 @@ typedef bool (* ConsolePrint)(void *con, char c);
 typedef ssize_t (* ConsoleOutFn)(const char *ptr, size_t len);
 
 /// A font struct for the console.
-///
-/// If convertSingleColor is true, the font is treated as a single color font
-/// where all non zero pixels are set to a value of 15 or 255 (4bpp / 8bpp
-/// respectivly). This ensures only one palette entry is utilized for font
-/// rendering.
 typedef struct ConsoleFont
 {
     u16 *gfx; ///< A pointer to the font graphics (will be loaded by consoleInit() if loadGraphics is true)

--- a/include/nds/arm9/decompress.h
+++ b/include/nds/arm9/decompress.h
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2024 Adrian "asie" Siekierka
 
-#if _BLOCKSDS_STRICT_ >= 10300 /* 1.3.0+ */
+#if BLOCKSDS_STRICT >= 10300 /* 1.3.0+ */
 #error This include file is no longer supported. Use <nds/decompress.h> instead.
 #endif
 

--- a/include/nds/arm9/decompress.h
+++ b/include/nds/arm9/decompress.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2024 Adrian "asie" Siekierka
+
+#if _BLOCKSDS_STRICT_ >= 10300 /* 1.3.0+ */
+#error This include file is no longer supported. Use <nds/decompress.h> instead.
+#endif
+
+#include <nds/decompress.h>

--- a/include/nds/arm9/input.h
+++ b/include/nds/arm9/input.h
@@ -79,7 +79,7 @@ uint32_t keysUp(void);
 /// @param data A touchPosition pointer which will be filled by the function.
 void touchRead(touchPosition *data);
 
-#if _BLOCKSDS_STRICT_ < 10300 /* 1.3.0+ */
+#if BLOCKSDS_STRICT < 10300 /* 1.3.0+ */
 // Old way of reading the touchpad state.
 static inline __attribute__((deprecated)) touchPosition touchReadXY(void)
 {

--- a/include/nds/arm9/input.h
+++ b/include/nds/arm9/input.h
@@ -79,6 +79,7 @@ uint32_t keysUp(void);
 /// @param data A touchPosition pointer which will be filled by the function.
 void touchRead(touchPosition *data);
 
+#if _BLOCKSDS_STRICT_ < 10300 /* 1.3.0+ */
 // Old way of reading the touchpad state.
 static inline __attribute__((deprecated)) touchPosition touchReadXY(void)
 {
@@ -86,6 +87,7 @@ static inline __attribute__((deprecated)) touchPosition touchReadXY(void)
     touchRead(&touchPos);
     return touchPos;
 }
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/nds/arm9/video.h
+++ b/include/nds/arm9/video.h
@@ -330,14 +330,6 @@ typedef _palette _ext_palette[16];
 /// @return The previous modes.
 u32 vramSetPrimaryBanks(VRAM_A_TYPE a, VRAM_B_TYPE b, VRAM_C_TYPE c, VRAM_D_TYPE d);
 
-// Same as vramSetPrimaryBanks(), but deprecated.
-__attribute__((deprecated))
-static inline u32 vramSetMainBanks(VRAM_A_TYPE a, VRAM_B_TYPE b, VRAM_C_TYPE c,
-                                   VRAM_D_TYPE d)
-{
-    return vramSetPrimaryBanks(a, b, c, d);
-}
-
 /// Set the mode of VRAM banks E, F and G.
 ///
 /// @param e Mapping mode of VRAM_E
@@ -354,17 +346,10 @@ u32 vramDefault(void);
 /// Restore the main 4 VRAM bank modes.
 ///
 /// Restores the main 4 banks to the value encoded in vramTemp (returned from
-/// vramSetMainBanks).
+/// vramSetPrimaryBanks).
 //
 /// @param vramTemp Value to restore the modes.
 static inline void vramRestorePrimaryBanks(u32 vramTemp)
-{
-    VRAM_CR = vramTemp;
-}
-
-// Same as vramRestorePrimaryBanks(), but deprecated.
-__attribute__((deprecated))
-static inline void vramRestoreMainBanks(u32 vramTemp)
 {
     VRAM_CR = vramTemp;
 }

--- a/include/nds/bios.h
+++ b/include/nds/bios.h
@@ -94,7 +94,7 @@ typedef struct UnpackStruct
     /// Bits 0-30 are added to all non-zero destination writes. If bit 31 is
     /// set they are added to zeroes too.
     uint32_t dataOffset;
-} PACKED TUnpackStruct, __attribute__((deprecated)) *PUnpackStruct;
+} PACKED TUnpackStruct;
 
 /// Resets the DS.
 __attribute__((always_inline, noreturn))

--- a/include/nds/fifocommon.h
+++ b/include/nds/fifocommon.h
@@ -38,8 +38,6 @@ typedef enum
     FIFO_USER_06    = 13, ///< Channel available for users
     FIFO_USER_07    = 14, ///< Channel available for users
     FIFO_USER_08    = 15, ///< Channel available for users
-
-    FIFO_SDMMC      = 5,  ///< Deprecated name of FIFO_STORAGE
 } FifoChannels;
 
 /// Enum values for the FIFO sound commands.

--- a/include/nds/interrupts.h
+++ b/include/nds/interrupts.h
@@ -28,7 +28,6 @@ extern "C" {
 #define IRQ_TIMER2          BIT(5)  ///< Timer 2 interrupt mask
 #define IRQ_TIMER3          BIT(6)  ///< Timer 3 interrupt mask
 #ifdef ARM7
-#define IRQ_NETWORK         BIT(7)  ///< Serial/RTC interrupt mask (ARM7) (deprecated name)
 #define IRQ_RTC             BIT(7)  ///< Serial/RTC interrupt mask (ARM7)
 #endif
 #define IRQ_DMA0            BIT(8)  ///< DMA 0 interrupt mask

--- a/include/nds/jtypes.h
+++ b/include/nds/jtypes.h
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2024 Adrian "asie" Siekierka
 
-#if _BLOCKSDS_STRICT_ >= 1
+#if BLOCKSDS_STRICT >= 1
 #error This include file is no longer supported. Use <nds/ndstypes.h> instead.
 #endif
 

--- a/include/nds/jtypes.h
+++ b/include/nds/jtypes.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2024 Adrian "asie" Siekierka
+
+#if _BLOCKSDS_STRICT_ >= 1
+#error This include file is no longer supported. Use <nds/ndstypes.h> instead.
+#endif
+
+#include <nds/ndstypes.h>

--- a/include/nds/libversion.h
+++ b/include/nds/libversion.h
@@ -5,10 +5,18 @@
 #ifndef LIBNDS_NDS_LIBVERSION_H__
 #define LIBNDS_NDS_LIBVERSION_H__
 
+#define _BLOCKSDS_MAJOR_ 1
+#define _BLOCKSDS_MINOR_ 3
+#define _BLOCKSDS_PATCH_ 0
+
+#define _BLOCKSDS_STRICT_CURRENT_ (((_BLOCKSDS_MAJOR_) * 10000) + ((_BLOCKSDS_MINOR_) * 100) + (_BLOCKSDS_PATCH_))
+
+// The below defines mark the version of libnds with which BlocksDS tries to be compatible.
+
 #define _LIBNDS_MAJOR_ 1
 #define _LIBNDS_MINOR_ 8
-#define _LIBNDS_PATCH_ 0
+#define _LIBNDS_PATCH_ 2
 
-#define _LIBNDS_STRING "libnds release 1.8.0"
+#define _LIBNDS_STRING "BlocksDS " _BLOCKSDS_MAJOR_ "." _BLOCKSDS_MINOR_ "." _BLOCKSDS_PATCH_ " (like libnds " _LIBNDS_MAJOR_ "." _LIBNDS_MINOR_ "." _LIBNDS_PATCH_ ")"
 
 #endif // LIBNDS_NDS_LIBVERSION_H__

--- a/include/nds/libversion.h
+++ b/include/nds/libversion.h
@@ -5,11 +5,12 @@
 #ifndef LIBNDS_NDS_LIBVERSION_H__
 #define LIBNDS_NDS_LIBVERSION_H__
 
-#define _BLOCKSDS_MAJOR_ 1
-#define _BLOCKSDS_MINOR_ 3
-#define _BLOCKSDS_PATCH_ 0
+#define BLOCKSDS_MAJOR_VERSION 1
+#define BLOCKSDS_MINOR_VERSION 3
+#define BLOCKSDS_PATCH_VERSION 0
 
-#define _BLOCKSDS_STRICT_CURRENT_ (((_BLOCKSDS_MAJOR_) * 10000) + ((_BLOCKSDS_MINOR_) * 100) + (_BLOCKSDS_PATCH_))
+#define BLOCKSDS_VERSIONNUM(major, minor, patch) (((major) * 10000) + ((minor) * 100) + (patch))
+#define BLOCKSDS_VERSIONNUM_CURRENT BLOCKSDS_VERSIONNUM(BLOCKSDS_MAJOR_VERSION, BLOCKSDS_MINOR_VERSION, BLOCKSDS_PATCH_VERSION)
 
 // The below defines mark the version of libnds with which BlocksDS tries to be compatible.
 

--- a/include/nds/ndstypes.h
+++ b/include/nds/ndstypes.h
@@ -138,9 +138,7 @@ typedef uint32_t sec_t;
 
 /// Function pointer that takes no arguments and doesn't return anything.
 typedef void (* VoidFn)(void);
-
 typedef void (* IntFn)(void);
-__attribute__((deprecated)) typedef void (* fp)(void);
 
 #ifdef __cplusplus
 }

--- a/include/nds/oldnames.h
+++ b/include/nds/oldnames.h
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Zlib
+// SPDX-FileNotice: Modified from the original version by the BlocksDS project.
+//
+// Copyright (C) 2005 Michael Noland (joat)
+// Copyright (C) 2005 Jason Rogers (dovoto)
+// Copyright (C) 2005 Dave Murphy (WinterMute)
+// Copyright (C) 2005 Chris Double (doublec)
+// Copyright (c) 2024 Adrian "asie" Siekierka
+
+#ifndef LIBNDS_NDS_OLDNAMES_H__
+#define LIBNDS_NDS_OLDNAMES_H__
+
+#include <nds/ndstypes.h>
+
+// This file contains a list of deprecated libnds names.
+// It is intended to be (mostly) machine-parseable.
+//
+// As such, all entries in it should, if possible, be in one of the following forms:
+//
+// - #define OLD_NAME NEW_NAME
+// - #define OLD_FUNCTION(a,b) NEW_FUNCTION(b,a)
+// - typedef new_type old_type;
+//
+// Versions should be marked by blocks of the following format:
+//
+// #if _BLOCKSDS_STRICT_ < first_unsupported_version /* first unsupported version+ OR libnds first unsupported version+ */
+// ... definitions ...
+// #endif
+//
+// For pre-BlocksDS changes, assume first_unsupported_version is 1.
+// Version blocks should always be listed from oldest to newest.
+
+#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.3.0 and below */
+
+// All hardware register defines should be replaced with REG_ for consistency
+// and namespacing.
+//
+// http://forum.gbadev.org/viewtopic.php?t=4993
+//
+// Replacements should follow gbatek standard naming where applicable; for example:
+//
+// https://github.com/devkitPro/libnds/commit/5e2ce19b49b60d69adf16fa79b2b440697a5cece
+// https://github.com/devkitPro/libnds/commit/fc3e1dffcbeb010179b652f20feb0b382f59b71b
+// https://github.com/devkitPro/libnds/commit/e4436bd86ff13dc08e3a910d4acd9eaf681637cd
+
+// Math registers
+
+#define DIV_CR              REG_DIVCNT
+
+#define DIV_NUMERATOR64     REG_DIV_NUMER
+#define DIV_NUMERATOR32     REG_DIV_NUMER_L
+
+#define DIV_DENOMINATOR64   REG_DIV_DENOM
+#define DIV_DENOMINATOR32   REG_DIV_DENOM_L
+
+#define DIV_RESULT64        REG_DIV_RESULT
+#define DIV_RESULT32        REG_DIV_RESULT_L
+
+#define DIV_REMAINDER64     REG_DIVREM_RESULT
+#define DIV_REMAINDER32     REG_DIVREM_RESULT_L
+
+#define SQRT_CR             REG_SQRTCNT
+
+#define SQRT_PARAM64        REG_SQRT_PARAM
+#define SQRT_PARAM32        REG_SQRT_PARAM_L
+
+#define SQRT_RESULT32       REG_SQRT_RESULT
+
+#define DISPLAY_CR          REG_DISPCNT
+
+#ifdef ARM9
+#define WAIT_CR             REG_EXMEMCNT
+#else
+#define WAIT_CR             REG_EXMEMSTAT
+#endif
+
+#define DISP_SR             REG_DISPSTAT
+#define DISP_Y              REG_VCOUNT
+
+#define BG0_CR              REG_BG0CNT
+#define BG1_CR              REG_BG1CNT
+#define BG2_CR              REG_BG2CNT
+#define BG3_CR              REG_BG3CNT
+
+#define BG0_X0              REG_BG0HOFS
+#define BG0_Y0              REG_BG0VOFS
+#define BG1_X0              REG_BG1HOFS
+#define BG1_Y0              REG_BG1VOFS
+#define BG2_X0              REG_BG2HOFS
+#define BG2_Y0              REG_BG2VOFS
+#define BG3_X0              REG_BG3HOFS
+#define BG3_Y0              REG_BG3VOFS
+
+#define BG2_XDX             REG_BG2PA
+#define BG2_XDY             REG_BG2PB
+#define BG2_YDX             REG_BG2PC
+#define BG2_YDY             REG_BG2PD
+#define BG2_CX              REG_BG2X
+#define BG2_CY              REG_BG2Y
+
+#define BG3_XDX             REG_BG3PA
+#define BG3_XDY             REG_BG3PB
+#define BG3_YDX             REG_BG3PC
+#define BG3_YDY             REG_BG3PD
+#define BG3_CX              REG_BG3X
+#define BG3_CY              REG_BG3Y
+
+#define SERIAL_CR           REG_SPICNT
+#define SERIAL_DATA         REG_SPIDATA
+#define SIO_CR              REG_SIOCNT
+#define R_CR                REG_RCNT
+
+#define DISP_CAPTURE        REG_DISPCAPCNT
+
+#define BRIGHTNESS          REG_MASTER_BRIGHT
+#define SUB_BRIGHTNESS      REG_MASTER_BRIGHT_SUB
+
+#define SUB_DISPLAY_CR      REG_DISPCNT_SUB
+
+#define SUB_BG0_CR          REG_BG0CNT_SUB
+#define SUB_BG1_CR          REG_BG1CNT_SUB
+#define SUB_BG2_CR          REG_BG2CNT_SUB
+#define SUB_BG3_CR          REG_BG3CNT_SUB
+
+#define SUB_BG0_X0          REG_BG0HOFS_SUB
+#define SUB_BG0_Y0          REG_BG0VOFS_SUB
+#define SUB_BG1_X0          REG_BG1HOFS_SUB
+#define SUB_BG1_Y0          REG_BG1VOFS_SUB
+#define SUB_BG2_X0          REG_BG2HOFS_SUB
+#define SUB_BG2_Y0          REG_BG2VOFS_SUB
+#define SUB_BG3_X0          REG_BG3HOFS_SUB
+#define SUB_BG3_Y0          REG_BG3VOFS_SUB
+
+#define SUB_BG2_XDX         REG_BG2PA_SUB
+#define SUB_BG2_XDY         REG_BG2PB_SUB
+#define SUB_BG2_YDX         REG_BG2PC_SUB
+#define SUB_BG2_YDY         REG_BG2PD_SUB
+#define SUB_BG2_CX          REG_BG2X_SUB
+#define SUB_BG2_CY          REG_BG2Y_SUB
+
+#define SUB_BG3_XDX         REG_BG3PA_SUB
+#define SUB_BG3_XDY         REG_BG3PB_SUB
+#define SUB_BG3_YDX         REG_BG3PC_SUB
+#define SUB_BG3_YDY         REG_BG3PD_SUB
+#define SUB_BG3_CX          REG_BG3X_SUB
+#define SUB_BG3_CY          REG_BG3Y_SUB
+
+#define KEYS                REG_KEYINPUT
+#define KEYS_CR             REG_KEYCNT
+
+#define IE                  REG_IE
+#define IF                  REG_IF
+#define IME                 REG_IME
+
+#define POWER_CR            REG_POWERCNT
+#endif
+
+#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.3.3+ */
+#define SOUND_CR            REG_SOUNDCNT
+#define SOUND_MASTER_VOL    REG_MASTER_VOLUME
+#define SOUND_BIAS          REG_SOUNDBIAS
+
+#define BLEND_CR            REG_BLDCNT
+#define BLEND_AB            REG_BLDALPHA
+#define BLEND_Y             REG_BLDY
+
+#define SUB_BLEND_CR        REG_BLDCNT_SUB
+#define SUB_BLEND_AB        REG_BLDALPHA_SUB
+#define SUB_BLEND_Y         REG_BLDY_SUB
+
+#define REG_BLDMOD_SUB      REG_BLDCNT_SUB
+#define REG_COLV_SUB        REG_BLDALPHA_SUB
+#define REG_COLY_SUB        REG_BLDY_SUB
+#endif
+
+#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.3.5+ */
+#define MOSAIC_CR           REG_MOSAIC
+#define SUB_MOSAIC_CR       REG_MOSAIC_SUB
+#endif
+
+#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.4.5+ */
+#define CARD_CR1            REG_AUXSPICNT
+#define CARD_CR1H           REG_AUXSPICNTH
+#define CARD_CR2            REG_ROMCTRL
+#define CARD_EEPDATA        REG_AUXSPIDATA
+#endif
+
+#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.7.0+ */
+#define CARD_COMMAND        REG_CARD_COMMAND
+#define CARD_DATA_RD        REG_CARD_DATA_RD
+#define CARD_1B0            REG_CARD_1B0
+#define CARD_1B4            REG_CARD_1B4
+#define CARD_1B8            REG_CARD_1B8
+#define CARD_1BA            REG_CARD_1BA
+#endif
+
+#if _BLOCKSDS_STRICT_ < 300 /* 0.3.0+ */
+#define IRQ_NETWORK         IRQ_RTC ///< \deprecated Replaced in BlocksDS 0.3.0 by IRQ_RTC.
+#define FIFO_SDMMC          FIFO_STORAGE ///< \deprecated Replaced in BlocksDS 0.3.0 by FIFO_STORAGE.
+#endif
+
+#if _BLOCKSDS_STRICT_ < 10300 /* 1.3.0+ */
+#define PUnpackStruct       TUnpackStruct*
+__attribute__((deprecated)) typedef void (* fp)(void);
+#define RTCtime             rtcTimeAndDate
+#define vramSetMainBanks    vramSetPrimaryBanks
+#define vramRestoreMainBanks vramRestorePrimaryBanks
+
+#ifdef ARM7
+#define RTC_CR              REG_RTCCNT
+#define RTC_CR8             REG_RTCCNT8
+#endif
+#ifdef ARM9
+#define HALT_CR             REG_HALTCNT
+#endif
+#endif
+
+#endif // LIBNDS_NDS_OLDNAMES_H__

--- a/include/nds/oldnames.h
+++ b/include/nds/oldnames.h
@@ -194,6 +194,28 @@
 #define CARD_1BA            REG_CARD_1BA
 #endif
 
+#if BLOCKSDS_STRICT < 100 /* 0.1.0+ */
+// picolibc tinystdio provides one global printf/scanf implementation.
+// The choice of integer-only or float-supporting variants is done at
+// link time.
+#define asiprintf           asprintf
+#define fiprintf            fprintf
+#define fiscanf             fscanf
+#define iprintf             printf
+#define iscanf              scanf
+#define siprintf            sprintf
+#define siscanf             sscanf
+#define sniprintf           snprintf
+#define vasiprintf          vasprintf
+#define vfiprintf           vfprintf
+#define vfiscanf            vfscanf
+#define viprintf            vprintf
+#define viscanf             vscanf
+#define vsiprintf           vsprintf
+#define vsiscanf            vsscanf
+#define vsniprintf          vsnprintf
+#endif
+
 #if BLOCKSDS_STRICT < 300 /* 0.3.0+ */
 #define IRQ_NETWORK         IRQ_RTC ///< \deprecated Replaced in BlocksDS 0.3.0 by IRQ_RTC.
 #define FIFO_SDMMC          FIFO_STORAGE ///< \deprecated Replaced in BlocksDS 0.3.0 by FIFO_STORAGE.

--- a/include/nds/oldnames.h
+++ b/include/nds/oldnames.h
@@ -209,6 +209,9 @@ __attribute__((deprecated)) typedef void (* fp)(void);
 #ifdef ARM7
 #define RTC_CR              REG_RTCCNT
 #define RTC_CR8             REG_RTCCNT8
+#define SerialWaitBusy      spiWaitBusy
+#define touchRead           tscRead
+#define touchReadTemperature tscReadTemperature
 #endif
 #ifdef ARM9
 #define HALT_CR             REG_HALTCNT

--- a/include/nds/oldnames.h
+++ b/include/nds/oldnames.h
@@ -199,6 +199,11 @@
 #define FIFO_SDMMC          FIFO_STORAGE ///< \deprecated Replaced in BlocksDS 0.3.0 by FIFO_STORAGE.
 #endif
 
+#if BLOCKSDS_STRICT < 700 /* 0.7.0+ */
+#define LUT_SIZE            (1 << 15)
+#define LUT_MASK            ((1 << 15) - 1)
+#endif
+
 #if BLOCKSDS_STRICT < 10300 /* 1.3.0+ */
 #define PUnpackStruct       TUnpackStruct*
 __attribute__((deprecated)) typedef void (* fp)(void);

--- a/include/nds/oldnames.h
+++ b/include/nds/oldnames.h
@@ -23,14 +23,14 @@
 //
 // Versions should be marked by blocks of the following format:
 //
-// #if _BLOCKSDS_STRICT_ < first_unsupported_version /* first unsupported version+ OR libnds first unsupported version+ */
+// #if BLOCKSDS_STRICT < first_unsupported_version /* first unsupported version+ OR libnds first unsupported version+ */
 // ... definitions ...
 // #endif
 //
 // For pre-BlocksDS changes, assume first_unsupported_version is 1.
 // Version blocks should always be listed from oldest to newest.
 
-#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.3.0 and below */
+#if BLOCKSDS_STRICT < 1 /* libnds 1.3.0 and below */
 
 // All hardware register defines should be replaced with REG_ for consistency
 // and namespacing.
@@ -155,7 +155,7 @@
 #define POWER_CR            REG_POWERCNT
 #endif
 
-#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.3.3+ */
+#if BLOCKSDS_STRICT < 1 /* libnds 1.3.3+ */
 #define SOUND_CR            REG_SOUNDCNT
 #define SOUND_MASTER_VOL    REG_MASTER_VOLUME
 #define SOUND_BIAS          REG_SOUNDBIAS
@@ -173,19 +173,19 @@
 #define REG_COLY_SUB        REG_BLDY_SUB
 #endif
 
-#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.3.5+ */
+#if BLOCKSDS_STRICT < 1 /* libnds 1.3.5+ */
 #define MOSAIC_CR           REG_MOSAIC
 #define SUB_MOSAIC_CR       REG_MOSAIC_SUB
 #endif
 
-#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.4.5+ */
+#if BLOCKSDS_STRICT < 1 /* libnds 1.4.5+ */
 #define CARD_CR1            REG_AUXSPICNT
 #define CARD_CR1H           REG_AUXSPICNTH
 #define CARD_CR2            REG_ROMCTRL
 #define CARD_EEPDATA        REG_AUXSPIDATA
 #endif
 
-#if _BLOCKSDS_STRICT_ < 1 /* libnds 1.7.0+ */
+#if BLOCKSDS_STRICT < 1 /* libnds 1.7.0+ */
 #define CARD_COMMAND        REG_CARD_COMMAND
 #define CARD_DATA_RD        REG_CARD_DATA_RD
 #define CARD_1B0            REG_CARD_1B0
@@ -194,12 +194,12 @@
 #define CARD_1BA            REG_CARD_1BA
 #endif
 
-#if _BLOCKSDS_STRICT_ < 300 /* 0.3.0+ */
+#if BLOCKSDS_STRICT < 300 /* 0.3.0+ */
 #define IRQ_NETWORK         IRQ_RTC ///< \deprecated Replaced in BlocksDS 0.3.0 by IRQ_RTC.
 #define FIFO_SDMMC          FIFO_STORAGE ///< \deprecated Replaced in BlocksDS 0.3.0 by FIFO_STORAGE.
 #endif
 
-#if _BLOCKSDS_STRICT_ < 10300 /* 1.3.0+ */
+#if BLOCKSDS_STRICT < 10300 /* 1.3.0+ */
 #define PUnpackStruct       TUnpackStruct*
 __attribute__((deprecated)) typedef void (* fp)(void);
 #define RTCtime             rtcTimeAndDate

--- a/include/nds/oldnames.h
+++ b/include/nds/oldnames.h
@@ -37,7 +37,7 @@
 //
 // http://forum.gbadev.org/viewtopic.php?t=4993
 //
-// Replacements should follow gbatek standard naming where applicable; for example:
+// Replacements may follow gbatek standard naming where applicable; for example:
 //
 // https://github.com/devkitPro/libnds/commit/5e2ce19b49b60d69adf16fa79b2b440697a5cece
 // https://github.com/devkitPro/libnds/commit/fc3e1dffcbeb010179b652f20feb0b382f59b71b

--- a/include/nds/registers_alt.h
+++ b/include/nds/registers_alt.h
@@ -5,84 +5,17 @@
 // Copyright (C) 2005 Jason Rogers (dovoto)
 // Copyright (C) 2005 Dave Murphy (WinterMute)
 // Copyright (C) 2005 Chris Double (doublec)
-
-// This file is deprecated.
-//
-// All hardware register defines should be replaced with REG_ for consistency
-// and namespacing.
-//
-// http://forum.gbadev.org/viewtopic.php?t=4993
+// Copyright (c) 2024 Adrian "asie" Siekierka
 
 #ifndef LIBNDS_NDS_REGISTERS_ALT_H__
 #define LIBNDS_NDS_REGISTERS_ALT_H__
 
+#include <nds/oldnames.h>
+
 #warning "header provided for assistance in porting to new register names, do not use for release code"
 
-#include <nds/ndstypes.h>
-
-// Math registers
-
-#define DIV_CR              REG_DIVCNT
-
-#define DIV_NUMERATOR64     REG_DIV_NUMER
-#define DIV_NUMERATOR32     REG_DIV_NUMER_L
-
-#define DIV_DENOMINATOR64   REG_DIV_DENOM
-#define DIV_DENOMINATOR32   REG_DIV_DENOM_L
-
-#define DIV_RESULT64        REG_DIV_RESULT
-#define DIV_RESULT32        REG_DIV_RESULT_L
-
-#define DIV_REMAINDER64     REG_DIVREM_RESULT
-#define DIV_REMAINDER32     REG_DIVREM_RESULT_L
-
-#define SQRT_CR             REG_SQRTCNT
-
-#define SQRT_PARAM64        REG_SQRT_PARAM
-#define SQRT_PARAM32        REG_SQRT_PARAM_L
-
-#define SQRT_RESULT32       REG_SQRT_RESULT
-
-// Graphics registers
-
-#define DISPLAY_CR          REG_DISPCNT
-
-#ifdef ARM9
-#define WAIT_CR             REG_EXMEMCNT
-#else
-#define WAIT_CR             REG_EXMEMSTAT
-#endif
-
-#define DISP_SR             REG_DISPSTAT
-#define DISP_Y              REG_VCOUNT
-
-#define BG0_CR              REG_BG0CNT
-#define BG1_CR              REG_BG1CNT
-#define BG2_CR              REG_BG2CNT
-#define BG3_CR              REG_BG3CNT
-
-#define BG0_X0              REG_BG0HOFS
-#define BG0_Y0              REG_BG0VOFS
-#define BG1_X0              REG_BG1HOFS
-#define BG1_Y0              REG_BG1VOFS
-#define BG2_X0              REG_BG2HOFS
-#define BG2_Y0              REG_BG2VOFS
-#define BG3_X0              REG_BG3HOFS
-#define BG3_Y0              REG_BG3VOFS
-
-#define BG2_XDX             REG_BG2PA
-#define BG2_XDY             REG_BG2PB
-#define BG2_YDX             REG_BG2PC
-#define BG2_YDY             REG_BG2PD
-#define BG2_CX              REG_BG2X
-#define BG2_CY              REG_BG2Y
-
-#define BG3_XDX             REG_BG3PA
-#define BG3_XDY             REG_BG3PB
-#define BG3_YDX             REG_BG3PC
-#define BG3_YDY             REG_BG3PD
-#define BG3_CX              REG_BG3X
-#define BG3_CY              REG_BG3Y
+// These registers are not yet migrated to the new REG_ standard, as described
+// in oldnames.h. This should be done eventually.
 
 #define REG_WIN0H           (*(vu16 *)0x4000040)
 #define REG_WIN1H           (*(vu16 *)0x4000042)
@@ -91,72 +24,12 @@
 #define REG_WININ           (*(vu16 *)0x4000048)
 #define REG_WINOUT          (*(vu16 *)0x400004A)
 
-#define MOSAIC_CR           REG_MOSAIC
-
-#define BLEND_CR            REG_BLDCNT
-#define BLEND_AB            REG_BLDALPHA
-#define BLEND_Y             REG_BLDY
-
-#define SUB_BLEND_CR        REG_BLDCNT_SUB
-#define SUB_BLEND_AB        REG_BLDALPHA_SUB
-#define SUB_BLEND_Y         REG_BLDY_SUB
-
-#define SERIAL_CR           REG_SPICNT
-#define SERIAL_DATA         REG_SPIDATA
-#define SIO_CR              REG_SIOCNT
-#define R_CR                REG_RCNT
-
-#define DISP_CAPTURE        REG_DISPCAPCNT
-
-#define BRIGHTNESS          REG_MASTER_BRIGHT
-#define SUB_BRIGHTNESS      REG_MASTER_BRIGHT_SUB
-
-// Secondary screen
-
-#define SUB_DISPLAY_CR      REG_DISPCNT_SUB
-
-#define SUB_BG0_CR          REG_BG0CNT_SUB
-#define SUB_BG1_CR          REG_BG1CNT_SUB
-#define SUB_BG2_CR          REG_BG2CNT_SUB
-#define SUB_BG3_CR          REG_BG3CNT_SUB
-
-#define SUB_BG0_X0          REG_BG0HOFS_SUB
-#define SUB_BG0_Y0          REG_BG0VOFS_SUB
-#define SUB_BG1_X0          REG_BG1HOFS_SUB
-#define SUB_BG1_Y0          REG_BG1VOFS_SUB
-#define SUB_BG2_X0          REG_BG2HOFS_SUB
-#define SUB_BG2_Y0          REG_BG2VOFS_SUB
-#define SUB_BG3_X0          REG_BG3HOFS_SUB
-#define SUB_BG3_Y0          REG_BG3VOFS_SUB
-
-#define SUB_BG2_XDX         REG_BG2PA_SUB
-#define SUB_BG2_XDY         REG_BG2PB_SUB
-#define SUB_BG2_YDX         REG_BG2PC_SUB
-#define SUB_BG2_YDY         REG_BG2PD_SUB
-#define SUB_BG2_CX          REG_BG2X_SUB
-#define SUB_BG2_CY          REG_BG2Y_SUB
-
-#define SUB_BG3_XDX         REG_BG3PA_SUB
-#define SUB_BG3_XDY         REG_BG3PB_SUB
-#define SUB_BG3_YDX         REG_BG3PC_SUB
-#define SUB_BG3_YDY         REG_BG3PD_SUB
-#define SUB_BG3_CX          REG_BG3X_SUB
-#define SUB_BG3_CY          REG_BG3Y_SUB
-
 #define REG_WIN0H_SUB       (*(vu16 *)0x4001040)
 #define REG_WIN1H_SUB       (*(vu16 *)0x4001042)
 #define REG_WIN0V_SUB       (*(vu16 *)0x4001044)
 #define REG_WIN1V_SUB       (*(vu16 *)0x4001046)
 #define REG_WININ_SUB       (*(vu16 *)0x4001048)
 #define REG_WINOUT_SUB      (*(vu16 *)0x400104A)
-
-#define SUB_MOSAIC_CR       REG_MOSAIC_SUB
-
-#define REG_BLDMOD_SUB      (*(vu16 *)0x4001050)
-#define REG_COLV_SUB        (*(vu16 *)0x4001052)
-#define REG_COLY_SUB        (*(vu16 *)0x4001054)
-
-/*common*/
 
 #define REG_DMA0SAD         (*(vu32 *)0x40000B0)
 #define REG_DMA0SAD_L       (*(vu16 *)0x40000B0)
@@ -207,25 +80,9 @@
 #define REG_TM3D            (*(vu16 *)0x400010C)
 #define REG_TM3CNT          (*(vu16 *)0x400010E)
 
-#define REG_SIOCNT          (*(vu16 *)0x4000128)
 #define REG_SIOMLT_SEND     (*(vu16 *)0x400012A)
 
-#define KEYS                REG_KEYINPUT
-#define KEYS_CR             REG_KEYCNT
-#define REG_RCNT            (*(vu16 *)0x4000134)
 #define REG_HS_CTRL         (*(vu16 *)0x4000140)
-
-// Interupt enable registers
-
-#define IE                  REG_IE
-#define IF                  REG_IF
-#define IME                 REG_IME
-
-// Controls power
-
-#define POWER_CR            REG_POWERCNT
-
-// VRAM control
 
 #define REG_VRAM_A_CR       (*(vu8 *)0x4000240)
 #define REG_VRAM_B_CR       (*(vu8 *)0x4000241)
@@ -237,8 +94,6 @@
 #define REG_VRAM_H_CR       (*(vu8 *)0x4000248)
 #define REG_VRAM_I_CR       (*(vu8 *)0x4000249)
 #define REG_WRAM_CNT        (*(vu8 *)0x4000247)
-
-// 3D graphics
 
 #define REG_GFX_FIFO        (*(vu32 *)0x4000400)
 #define REG_GFX_STATUS      (*(vu32 *)0x4000600)
@@ -280,35 +135,4 @@
 #define REG_MTX_MULT4x3     (*(volatile f32 *)0x4000464)
 #define REG_MTX_MULT3x3     (*(volatile f32 *)0x4000468)
 
-// Card bus
-
-#define CARD_CR1            REG_AUXSPICNT
-#define CARD_CR1H           REG_AUXSPICNTH
-#define CARD_CR2            REG_ROMCTRL
-#define CARD_EEPDATA        REG_AUXSPIDATA
-
-#define CARD_COMMAND        REG_CARD_COMMAND
-#define CARD_DATA_RD        REG_CARD_DATA_RD
-
-#define CARD_1B0            REG_CARD_1B0
-#define CARD_1B4            REG_CARD_1B4
-#define CARD_1B8            REG_CARD_1B8
-#define CARD_1BA            REG_CARD_1BA
-
-// Sound
-
-#define SOUND_CR            REG_SOUNDCNT
-#define SOUND_MASTER_VOL    REG_MASTER_VOLUME
-
-#define SOUND_BIAS          REG_SOUNDBIAS
-
-#ifdef ARM7
-#define RTC_CR              REG_RTCCNT
-#define RTC_CR8             REG_RTCCNT8
-#endif
-
-#ifdef ARM9
-#define HALT_CR             REG_HALTCNT
-#endif
-
-#endif // LIBNDS_NDS_REGISTERS_ALT_H__
+#endif /* LIBNDS_NDS_REGISTERS_ALT_H__ */

--- a/include/nds/registers_alt.h
+++ b/include/nds/registers_alt.h
@@ -12,7 +12,7 @@
 
 #include <nds/oldnames.h>
 
-#warning "header provided for assistance in porting to new register names, do not use for release code"
+#warning Header provided for assistance in porting to new register names, do not use for release code.
 
 // These registers are not yet migrated to the new REG_ standard, as described
 // in oldnames.h. This should be done eventually.

--- a/include/nds/system.h
+++ b/include/nds/system.h
@@ -433,19 +433,6 @@ typedef struct tPERSONAL_DATA
 #define PersonalData ((PERSONAL_DATA *)0x2FFFC80)
 
 /// Struct containing time and day of the real time clock.
-///
-/// Use rtcTimeAndDate instead.
-__attribute__((deprecated)) typedef struct {
-    u8 year;    ///< Add 2000 to get 4 digit year
-    u8 month;   ///< 1 to 12
-    u8 day;     ///< 1 to (days in month)
-    u8 weekday; ///< Day of week (0 = Sunday, 1 = Monday, ...,  6 = Saturday)
-    u8 hours;   ///< 0 to 11 for AM, 52 to 63 for PM
-    u8 minutes; ///< 0 to 59
-    u8 seconds; ///< 0 to 59
-} RTCtime;
-
-/// Struct containing time and day of the real time clock.
 typedef struct {
     u8 year;    ///< Add 2000 to get 4 digit year
     u8 month;   ///< 1 to 12


### PR DESCRIPTION
The idea here is that a new define is added, `BLOCKSDS_STRICT`, of the value `(major_version * 10000 + minor_version * 100 + patch_version)` for a given version of BlocksDS.

* By default, BlocksDS templates come with `BLOCKSDS_STRICT` defined to the version they are copied from; for example, BlocksDS 1.3.0 templates will come with `-DBLOCKSDS_STRICT=10300` as a default.
* If defined to a given BlocksDS version, all deprecations made in that version or earlier are made inaccessible (no function, type definitions, etc).
    * For example, `IRQ_NETWORK` was renamed to `IRQ_RTC` in BlocksDS 0.3.0, so the former name is only accessible for `BLOCKSDS_STRICT < 300`.
* If defined to `1`, we try to keep maximum reasonable compatibility with the latest upstream version of libnds.
* If not defined (or defined to `0`), we try to also keep compatibility with older versions of libnds.
* In code completion environments (clangd, IntelliSense, etc), we try to avoid displaying the deprecated variants.

The idea is to allow BlocksDS to gradually clean up and improve the code/naming quality of the libraries while providing shims and aliases for old naming, thus not breaking older homebrew projects (as much).

My main concern is that this is somewhat too over-engineered, but in discussions we seem to agree that maintaining a friendly migration path for older projects is a notable goal given the current state of NDS homebrew.

An alternate idea pitched was to fork `libnds` into an alternate `libnds2`, which removes and cleans up all the legacy stuff in one go. My concern with that is that code quality is an ongoing process - in a few years, we may well decide that we need a `libnds3`.