### PR TITLE
threads: add partial implementation of C11 threads API, wrapping cothreads

### DIFF
--- a/include/nds/cothread.h
+++ b/include/nds/cothread.h
@@ -23,6 +23,8 @@ extern "C" {
 typedef int cothread_t;
 /// Mutex
 typedef int comutex_t;
+/// Thread entrypoint
+typedef int (*cothread_entrypoint_t)(void *);
 
 /// Flags a thread as detached.
 ///
@@ -44,8 +46,9 @@ typedef int comutex_t;
 ///                   default value. If non-zero, it must be aligned to 64 bit.
 /// @param flags Set of ORed flags (like COTHREAD_DETACHED) or 0.
 ///
-/// @return On success, it returns 0. On failure, it returns -1 and sets errno.
-cothread_t cothread_create(int (*entrypoint)(void *), void *arg,
+/// @return On success, it returns a non-negative value representing the thread
+/// ID. On failure, it returns -1 and sets errno.
+cothread_t cothread_create(cothread_entrypoint_t entrypoint, void *arg,
                            size_t stack_size, unsigned int flags);
 
 /// Create a thread.
@@ -61,8 +64,9 @@ cothread_t cothread_create(int (*entrypoint)(void *), void *arg,
 /// @param stack_size Size of the stack. Must be aligned to 64 bit.
 /// @param flags Set of ORed flags (like COTHREAD_DETACHED) or 0.
 ///
-/// @return On success, it returns 0. On failure, it returns -1 and sets errno.
-cothread_t cothread_create_manual(int (*entrypoint)(void *), void *arg,
+/// @return On success, it returns a non-negative value representing the thread
+/// ID. On failure, it returns -1 and sets errno.
+cothread_t cothread_create_manual(cothread_entrypoint_t entrypoint, void *arg,
                                   void *stack_base, size_t stack_size,
                                   unsigned int flags);
 

--- a/include/threads.h
+++ b/include/threads.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2024 Adrian "asie" Siekiekra
+
+#ifndef THREADS_H__
+#define THREADS_H__
+
+#include <nds/cothread.h>
+
+// Partial implementation of C11 threads.h.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef cothread_t thrd_t;
+enum {
+    thrd_success = 0,
+    thrd_error = -1,
+    thrd_timedout = -2,
+    thrd_busy = -3,
+    thrd_nomem = -4
+};
+
+typedef void (*thrd_start_t)(void*);
+
+int thrd_create(thrd_t *thr, thrd_start_t func, void *arg);
+int thrd_join(thrd_t thr, int *res);
+
+static inline thrd_t thrd_current(void)
+{
+    return cothread_get_current();
+}
+
+static inline int thrd_detach(thrd_t thr)
+{
+    return cothread_detach(thr);
+}
+
+static inline int thrd_equal(thrd_t thr0, thrd_t thr1)
+{
+    return thr0 == thr1;
+}
+
+static inline void thrd_yield(void)
+{
+    cothread_yield();
+}
+
+typedef comutex_t mtx_t;
+enum
+{
+    mtx_plain = 0
+};
+
+static inline int mtx_init(mtx_t *mtx, int type)
+{
+    (void)type;
+    return comutex_init(mtx) ? thrd_success : thrd_error;
+}
+
+static inline int mtx_lock(mtx_t *mtx)
+{
+    comutex_acquire(mtx);
+    return thrd_success;
+}
+
+static inline int mtx_trylock(mtx_t *mtx)
+{
+    return comutex_try_acquire(mtx) ? thrd_success : thrd_error;
+}
+
+static inline int mtx_unlock(mtx_t *mtx)
+{
+    comutex_release(mtx);
+    return thrd_success;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // THREADS_H__

--- a/source/arm9/libc/threads.c
+++ b/source/arm9/libc/threads.c
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2024 3 Adrian "asie" Siekierka
+
+#include <errno.h>
+#include <nds/cothread.h>
+#include <threads.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+
+int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
+{
+    thrd_t thread = cothread_create((cothread_entrypoint_t) func, arg, 0, 0);
+
+    if (thread < 0)
+    {
+        return errno == ENOMEM ? thrd_nomem : thrd_error;
+    }
+    else
+    {
+        if (thr != NULL)
+            *thr = thread;
+
+        return thrd_success;
+    }
+}
+
+#pragma GCC diagnostic pop
+
+int thrd_join(thrd_t thr, int *res)
+{
+    while (!cothread_has_joined(thr))
+        cothread_yield();
+
+    if (res != NULL)
+        *res = cothread_get_exit_code(thr);
+
+    return thrd_success;
+}


### PR DESCRIPTION
It's very incomplete, as it only maps those functions of <threads.h> which our cothread/comutex system already implements.