### PR TITLE
Make transfer region public again

### DIFF
--- a/include/nds.h
+++ b/include/nds.h
@@ -144,6 +144,7 @@ extern "C" {
 #include <nds/sha1.h>
 #include <nds/system.h>
 #include <nds/timers.h>
+#include <nds/transfer_region.h>
 #include <nds/touch.h>
 
 #ifdef ARM9

--- a/include/nds/transfer_region.h
+++ b/include/nds/transfer_region.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Zlib
+// SPDX-FileNotice: Modified from the original version by the BlocksDS project.
+//
+// Copyright (C) 2005-2008 Dave Murphy (WinterMute)
+// Copyright (c) 2023-2024 Antonio Niño Díaz
+
+#ifndef LIBNDS_TRANSFER_REGION_H__
+#define LIBNDS_TRANSFER_REGION_H__
+
+#include <time.h>
+
+#include <nds/ndstypes.h>
+#include <nds/system.h>
+
+typedef struct TransferRegion
+{
+    time_t unixTime;
+    struct __bootstub *bootcode;
+} TransferRegion, *pTransferRegion;
+
+static inline TransferRegion volatile *transferRegion(void)
+{
+    // The transfer region address needs to be in an uncached mirror of main RAM
+    // so that the code doesn't need to do any special cache handling when
+    // trying to read updated values, or trying to ensure that the new value can
+    // be read by the other CPU. The following regions are mapped in the MPU:
+    //
+    //            Cached main RAM            Uncached main RAM mirrors
+    //
+    // DS         0x2000000-0x2400000 (4M)   0x2400000-0x3000000 (12M) (3 times)
+    // DS debug   0x2000000-0x2800000 (8M)   0x2800000-0x3000000 (8M)
+    // DSi        0x2000000-0x3000000 (16M)  0xC000000-0xD000000 (16M)
+    // DSi debug  0x2000000-0x3000000 (16M)  0xC000000-0xE000000 (32M)
+    //
+    // Also, it's important that the region isn't in DTCM, as it can't be seen
+    // from the ARM7:
+    //
+    //            0x2FF0000-0x2FF4000 (16K)
+    //
+    // In DS mode, 0x2FFF000 is a good address, as it is inside an uncached main
+    // RAM mirror, and outside DTCM. In a regular DSi, 0xCFFF000 is an
+    // equivalent address.
+    //
+    // The only problem is the DSi debugger model. The main RAM of DSi at
+    // 0xC000000 isn't mirrored at 0xD000000, so it isn't possible to use the
+    // same address (let's say 0xDFFF000) for both the DSi (16 MB) and DSi
+    // debugger (32 MB).
+    //
+    // This function could select different locations for each models but the
+    // added complexity isn't worth it: The ARM9 linkerscript doesn't support
+    // the additional 16 MB of the DSi debugger.
+    if (isDSiMode())
+        return (TransferRegion volatile *)0x0CFFF000;
+    else
+        return (TransferRegion volatile *)0x02FFF000;
+}
+
+#define IPC transferRegion()
+
+#endif // LIBNDS_TRANSFER_REGION_H__

--- a/source/arm7/clock.c
+++ b/source/arm7/clock.c
@@ -13,9 +13,8 @@
 #include <nds/interrupts.h>
 #include <nds/ipc.h>
 #include <nds/timers.h>
+#include <nds/transfer_region.h>
 #include <nds/system.h>
-
-#include "common/libnds_internal.h"
 
 // Delay (in swiDelay units) for each bit transfer
 #define RTC_DELAY 48
@@ -180,7 +179,7 @@ __attribute__((deprecated)) void rtcSetTime(uint8_t *time)
 
 static void syncRTC(void)
 {
-    __transferRegion()->unixTime++;
+    transferRegion()->unixTime++;
 }
 
 /* Nonzero if `y' is a leap year, else zero. */
@@ -363,7 +362,7 @@ void resyncClock(void)
     rtcTimeAndDate dstime;
     rtcTimeAndDateGet(&dstime);
 
-    __transferRegion()->unixTime = __mktime(&dstime);
+    transferRegion()->unixTime = __mktime(&dstime);
 }
 
 __attribute__((deprecated)) void initClockIRQ(void)

--- a/source/arm9/system/initSystem.c
+++ b/source/arm9/system/initSystem.c
@@ -18,8 +18,8 @@
 #include <nds/ndstypes.h>
 #include <nds/system.h>
 #include <nds/timers.h>
+#include <nds/transfer_region.h>
 
-#include "common/libnds_internal.h"
 
 bool __dsimode; // Set by the crt0
 bool __debugger_unit; // Set by the crt0
@@ -65,9 +65,9 @@ void __attribute__((weak)) initSystem(void)
     fifoSetValue32Handler(FIFO_SYSTEM, systemValueHandler, 0);
     fifoSetDatamsgHandler(FIFO_SYSTEM, systemMsgHandler, 0);
 
-    punixTime = (time_t *)memUncached((void *)&__transferRegion()->unixTime);
+    punixTime = (time_t *)memUncached((void *)&transferRegion()->unixTime);
 
     extern char *fake_heap_end;
-    __transferRegion()->bootcode = (struct __bootstub *)fake_heap_end;
+    transferRegion()->bootcode = (struct __bootstub *)fake_heap_end;
     irqEnable(IRQ_VBLANK);
 }

--- a/source/common/libc/exit.c
+++ b/source/common/libc/exit.c
@@ -7,9 +7,9 @@
 #include <stdlib.h>
 #include <nds/fifocommon.h>
 #include <nds/system.h>
+#include <nds/transfer_region.h>
 
 #include "../fifo_ipc_messages.h"
-#include "../libnds_internal.h"
 
 extern char *fake_heap_end;
 
@@ -40,7 +40,7 @@ ARM_CODE void _exit(int rc)
     if (rc != 0)
         systemErrorExit(rc);
 
-    struct __bootstub *bootcode = __transferRegion()->bootcode;
+    struct __bootstub *bootcode = transferRegion()->bootcode;
 
     if (bootcode->bootsig == BOOTSIG)
     {

--- a/source/common/libc/syscalls.c
+++ b/source/common/libc/syscalls.c
@@ -8,6 +8,8 @@
 #include <sys/times.h>
 #include <time.h>
 
+#include <nds/transfer_region.h>
+
 #include "../libnds_internal.h"
 
 // This file implements stubs for system calls. For more information about it,
@@ -107,7 +109,7 @@ int gettimeofday(struct timeval *tp, void *tz)
         tp->tv_sec = *punixTime;
         tp->tv_usec = 0;
 #else
-        tp->tv_sec = __transferRegion()->unixTime;
+        tp->tv_sec = transferRegion()->unixTime;
         tp->tv_usec = 0;
 #endif
     }

--- a/source/common/libnds_internal.h
+++ b/source/common/libnds_internal.h
@@ -10,54 +10,9 @@
 #define COMMON_LIBNDS_INTERNAL_H__
 
 #include <stdio.h>
-#include <time.h>
 
 #include <nds/arm9/input.h>
 #include <nds/ndstypes.h>
-#include <nds/system.h>
-
-typedef struct __TransferRegion
-{
-    time_t unixTime;
-    struct __bootstub *bootcode;
-} __TransferRegion, *__pTransferRegion;
-
-static inline __TransferRegion volatile *__transferRegion(void)
-{
-    // The transfer region address needs to be in an uncached mirror of main RAM
-    // so that the code doesn't need to do any special cache handling when
-    // trying to read updated values, or trying to ensure that the new value can
-    // be read by the other CPU. The following regions are mapped in the MPU:
-    //
-    //            Cached main RAM            Uncached main RAM mirrors
-    //
-    // DS         0x2000000-0x2400000 (4M)   0x2400000-0x3000000 (12M) (3 times)
-    // DS debug   0x2000000-0x2800000 (8M)   0x2800000-0x3000000 (8M)
-    // DSi        0x2000000-0x3000000 (16M)  0xC000000-0xD000000 (16M)
-    // DSi debug  0x2000000-0x3000000 (16M)  0xC000000-0xE000000 (32M)
-    //
-    // Also, it's important that the region isn't in DTCM, as it can't be seen
-    // from the ARM7:
-    //
-    //            0x2FF0000-0x2FF4000 (16K)
-    //
-    // In DS mode, 0x2FFF000 is a good address, as it is inside an uncached main
-    // RAM mirror, and outside DTCM. In a regular DSi, 0xCFFF000 is an
-    // equivalent address.
-    //
-    // The only problem is the DSi debugger model. The main RAM of DSi at
-    // 0xC000000 isn't mirrored at 0xD000000, so it isn't possible to use the
-    // same address (let's say 0xDFFF000) for both the DSi (16 MB) and DSi
-    // debugger (32 MB).
-    //
-    // This function could select different locations for each models but the
-    // added complexity isn't worth it: The ARM9 linkerscript doesn't support
-    // the additional 16 MB of the DSi debugger.
-    if (isDSiMode())
-        return (__TransferRegion volatile *)0x0CFFF000;
-    else
-        return (__TransferRegion volatile *)0x02FFF000;
-}
 
 void setTransferInputData(touchPosition *touch, u16 buttons);
 void __libnds_exit(int rc);


### PR DESCRIPTION
At some point in the early years of libnds, the transfer region was made private and all programs that used it stopped building. This was made in order to make people use the FIFO functions, which are more reliable.

However, even though it's very discouraged to use this, it can be useful to port old programs to the current version of libnds.

This is probably a polemic change but, honestly, I think it's a good idea. So far, I've been hardcoding the address of the transfer region structures of the games I've ported to BlocksDS (https://github.com/AntonioND/wolveslayer and https://github.com/AntonioND/talesofdagur) as a temporary step before migrating to using the FIFO, but porting old games is pretty hard, so it's still nice to have the option of delaying the migration from transfer region to FIFO (which is arguably the biggest change you have to make...).