### PR TITLE
exceptions: Refactor exception and crash handling

### DIFF
--- a/include/nds/arm9/exceptions.h
+++ b/include/nds/arm9/exceptions.h
@@ -46,8 +46,17 @@ void enterException(void);
 ///     Exception handler routine.
 void setExceptionHandler(VoidFn handler);
 
-/// Sets the default hardware exception handler.
+/// Sets the default debug hardware exception handler.
+///
+/// This handler prints a lot of information, like the state of the CPU
+/// registers when the CPU crashed.
 void defaultExceptionHandler(void);
+
+/// Sets the release hardware exception handler.
+///
+/// This is similar to defaultExceptionHandler(), but it only prints a minimal
+/// error message, and it uses a lot less code to do it.
+void releaseExceptionHandler(void);
 
 #ifdef __cplusplus
 }

--- a/source/arm7/libnds_internal.h
+++ b/source/arm7/libnds_internal.h
@@ -25,4 +25,13 @@ typedef struct {
  */
 libnds_touchMeasurementFilterResult libnds_touchMeasurementFilter(u16 values[5]);
 
+// In the ARM7 we can't really print anything without adding a lot of additional
+// code, so just crash in a controlled way.
+__attribute__((always_inline, noreturn))
+THUMB_CODE static inline void libndsCrash(__attribute__((unused)) const char *message)
+{
+    asm volatile("udf" ::: "memory");
+    while (1);
+}
+
 #endif // ARM7_LIBNDS_INTERNAL_H__

--- a/source/arm9/libnds_internal.h
+++ b/source/arm9/libnds_internal.h
@@ -12,4 +12,8 @@ extern ConsoleOutFn libnds_stdout_write, libnds_stderr_write;
 
 void setTransferInputData(touchPosition *touch, u16 buttons);
 
+// In the ARM9, this function will cause an exception that will print the
+// provided message.
+__attribute__((noreturn)) void libndsCrash(const char *message);
+
 #endif // ARM9_LIBNDS_INTERNAL_H__

--- a/source/arm9/system/exceptionHandler.s
+++ b/source/arm9/system/exceptionHandler.s
@@ -64,7 +64,7 @@ BEGIN_ASM_FUNC enterException
     ldr     r13, [r12, #(oldStack - exceptionRegisters)]
 
     // Return through BIOS
-    mov    pc, lr
+    mov     pc, lr
 
 
     .global exceptionC

--- a/source/arm9/system/gurumeditation.c
+++ b/source/arm9/system/gurumeditation.c
@@ -2,17 +2,22 @@
 // SPDX-FileNotice: Modified from the original version by the BlocksDS project.
 //
 // Copyright (C) 2005 Dave Murphy (WinterMute)
+// Copyright (c) 2024 Antonio Niño Díaz
 
 #include <stdio.h>
+#include <string.h>
 
 #include <nds/arm9/background.h>
 #include <nds/arm9/console.h>
 #include <nds/arm9/exceptions.h>
 #include <nds/arm9/video.h>
 #include <nds/cpu_asm.h>
+#include <nds/interrupts.h>
 #include <nds/memory.h>
 #include <nds/ndstypes.h>
 #include <nds/system.h>
+
+const char *exceptionMsg = NULL;
 
 uint32_t ARMShift(uint32_t value, uint8_t shift)
 {
@@ -216,17 +221,11 @@ u32 getExceptionAddress(u32 opcodeAddress, u32 thumbState)
     return 0;
 }
 
-static const char *registerNames[] =
-{
-    "r0",  "r1",  "r2",  "r3",  "r4",  "r5", "r6",  "r7",
-    "r8 ", "r9 ", "r10", "r11", "r12", "sp ", "lr ", "pc "
-};
-
-// Symbol defined in the linkerscript
-extern const char __itcm_start[];
-
+__attribute__((noreturn))
 void guruMeditationDump(void)
 {
+    REG_IME = 0;
+
     consoleDemoInit();
 
     // White text on a red background
@@ -244,53 +243,22 @@ void guruMeditationDump(void)
     // the exception.
     u32 thumbState = *(EXCEPTION_STACK_TOP - 3) & CPSR_FLAG_T;
 
-    u32 codeAddress, exceptionAddress = 0;
+    u32 codeAddress = 0, exceptionAddress = 0;
 
     int offset = 8;
 
-    if (currentMode == CPSR_MODE_ABORT)
+    bool print_information = true;
+
+    if (exceptionMsg != NULL)
     {
-        consoleSetCursor(NULL, 10, 1);
-        printf("data abort!\n\n");
+        size_t tab = (32 - strlen(exceptionMsg)) / 2;
+        if (tab > 16)
+            tab = 0;
+        consoleSetCursor(NULL, tab, 1);
+        printf("%s\n\n", exceptionMsg);
 
-        // In a data abort, there is an instruction that tried to access an
-        // invalid address, and an invalid address.
-
-        // Get the address where the exception was triggered
-
-        codeAddress = exceptionRegisters[15] - offset;
-
-        // Check if the address is a region that normally contains code
-
-        // TODO: Support DS debugger regions?
-        bool is_main_ram;
-        if (isDSiMode())
-            is_main_ram = codeAddress > 0x02000000 && codeAddress < 0x03000000;
-        else
-            is_main_ram = codeAddress > 0x02000000 && codeAddress < 0x02400000;
-
-        bool is_itcm = codeAddress > (u32)__itcm_start
-                       && codeAddress < (u32)(__itcm_start + 32768);
-
-        // If it's in a code region, try to decode the instruction. This will
-        // let us know exactly which address was trying to be accessed.
-
-        if (is_main_ram || is_itcm)
-            exceptionAddress = getExceptionAddress(codeAddress, thumbState);
-        else
-            exceptionAddress = codeAddress;
-    }
-    else
-    {
-        consoleSetCursor(NULL, 5, 1);
-        printf("undefined instruction!\n\n");
-
-        // Get the address where the exception was triggered, which is the one
-        // that holds the undefined instruction, so it's the same address as the
-        // exception address.
-
-        // That PC will have advanced one instruction, so the actual location of
-        // the undefined instruction is one instruction before the current PC.
+        // This should have happened because of an undefined instruction, get
+        // information the same way.
         if (thumbState)
             offset = 2;
         else
@@ -299,29 +267,101 @@ void guruMeditationDump(void)
         codeAddress = exceptionRegisters[15] - offset;
         exceptionAddress = codeAddress;
     }
-
-    // Finally, print everything to the screen
-
-    printf("  pc: %08lX addr: %08lX\n\n", codeAddress, exceptionAddress);
-
-    for (int i = 0; i < 8; i++)
+    else
     {
-        printf("  %s: %08lX   %s: %08lX\n", registerNames[i], exceptionRegisters[i],
-               registerNames[i + 8], exceptionRegisters[i + 8]);
+        if (currentMode == CPSR_MODE_ABORT)
+        {
+            consoleSetCursor(NULL, 10, 1);
+            printf("Data abort!\n\n");
+
+            // In a data abort, there is an instruction that tried to access an
+            // invalid address, and an invalid address.
+
+            // Get the address where the exception was triggered
+
+            codeAddress = exceptionRegisters[15] - offset;
+
+            // Check if the address is a region that normally contains code
+
+            // TODO: Support DS debugger regions?
+            bool is_main_ram;
+            if (isDSiMode())
+                is_main_ram = codeAddress > 0x02000000 && codeAddress < 0x03000000;
+            else
+                is_main_ram = codeAddress > 0x02000000 && codeAddress < 0x02400000;
+
+            // Symbol defined in the linkerscript
+            extern const char __itcm_start[];
+
+            bool is_itcm = codeAddress > (u32)__itcm_start
+                        && codeAddress < (u32)(__itcm_start + 32768);
+
+            // If it's in a code region, try to decode the instruction. This
+            // will let us know exactly which address was trying to be accessed.
+
+            if (is_main_ram || is_itcm)
+                exceptionAddress = getExceptionAddress(codeAddress, thumbState);
+            else
+                exceptionAddress = codeAddress;
+        }
+        else if (currentMode == CPSR_MODE_UNDEFINED)
+        {
+            consoleSetCursor(NULL, 5, 1);
+            printf("Undefined instruction!\n\n");
+
+            // Get the address where the exception was triggered, which is the
+            // one that holds the undefined instruction, so it's the same
+            // address as the exception address.
+
+            // That PC will have advanced one instruction, so the actual
+            // location of the undefined instruction is one instruction before
+            // the current PC.
+            if (thumbState)
+                offset = 2;
+            else
+                offset = 4;
+
+            codeAddress = exceptionRegisters[15] - offset;
+            exceptionAddress = codeAddress;
+        }
+        else
+        {
+            consoleSetCursor(NULL, 8, 1);
+            printf("unknown error!\n\n");
+
+            // If we're here because of an unknown error we can't print anything
+            print_information = false;
+        }
     }
 
-    printf("\n");
-    u32 *stack = (u32 *)exceptionRegisters[13];
-    for (int i = 0; i < 10; i++)
+    if (print_information)
     {
-        consoleSetCursor(NULL, 2, i + 14);
-        printf("%08lX:  %08lX %08lX", (u32)&stack[i * 2], stack[i * 2], stack[(i * 2) + 1]);
-    }
-}
+        // Finally, print everything to the screen
 
-static void defaultHandler(void)
-{
-    guruMeditationDump();
+        printf("  pc: %08lX addr: %08lX\n\n", codeAddress, exceptionAddress);
+
+        for (int i = 0; i < 8; i++)
+        {
+            const char *registerNames[] =
+            {
+                "r0",  "r1",  "r2",  "r3",  "r4",  "r5", "r6",  "r7",
+                "r8 ", "r9 ", "r10", "r11", "r12", "sp ", "lr ", "pc "
+            };
+
+            printf("  %s: %08lX   %s: %08lX\n",
+                   registerNames[i], exceptionRegisters[i],
+                   registerNames[i + 8], exceptionRegisters[i + 8]);
+        }
+
+        printf("\n");
+        u32 *stack = (u32 *)exceptionRegisters[13];
+        for (int i = 0; i < 10; i++)
+        {
+            consoleSetCursor(NULL, 2, i + 14);
+            printf("%08lX:  %08lX %08lX", (u32)&stack[i * 2],
+                   stack[i * 2], stack[(i * 2) + 1]);
+        }
+    }
 
     // We can't make any assumption about what happened before an exception. It
     // may have happened when dereferencing a NULL pointer before doing any
@@ -335,7 +375,73 @@ static void defaultHandler(void)
         ;
 }
 
+__attribute__((noreturn))
+static void defaultHandler(void)
+{
+    guruMeditationDump();
+}
+
 void defaultExceptionHandler(void)
 {
     setExceptionHandler(defaultHandler);
+}
+
+// ---------------------------------------
+
+__attribute__((noreturn))
+static void releaseCrashHandler(void)
+{
+    REG_IME = 0;
+
+    consoleDemoInit();
+
+    // White text on a red background
+    BG_PALETTE_SUB[0] = RGB15(15, 0, 0);
+    BG_PALETTE_SUB[255] = RGB15(31, 31, 31);
+
+    const char *msg = exceptionMsg;
+
+    if (msg == NULL)
+    {
+        // If there is no message, try to determine the reason for the crash.
+        // The current CPU mode specifies whether the exception was caused by a
+        // data abort or an undefined instruction.
+        u32 currentMode = getCPSR() & CPSR_MODE_MASK;
+        if (currentMode == CPSR_MODE_ABORT)
+            msg = "Data abort";
+        else if (currentMode == CPSR_MODE_UNDEFINED)
+            msg = "Undefined instruction";
+        else
+            msg = "Unknown error";
+    }
+
+    while (1)
+    {
+        char c = *msg++;
+        if (c == '\0')
+            break;
+
+        consolePrintChar(c);
+    }
+
+    while (1)
+        ;
+}
+
+void releaseExceptionHandler(void)
+{
+    setExceptionHandler(releaseCrashHandler);
+}
+
+// ---------------------------------------
+
+__attribute__((noreturn))
+void libndsCrash(const char *msg)
+{
+    exceptionMsg = msg;
+
+    // Use an undefined instruction defined by the assembler
+    asm volatile("udf" ::: "memory");
+
+    while (1);
 }

--- a/source/arm9/system/initSystem.c
+++ b/source/arm9/system/initSystem.c
@@ -7,6 +7,7 @@
 
 #include <time.h>
 
+#include <nds/arm9/exceptions.h>
 #include <nds/arm9/input.h>
 #include <nds/arm9/sprite.h>
 #include <nds/arm9/video.h>
@@ -38,6 +39,13 @@ void __attribute__((weak)) initSystem(void)
         TIMER_CR(i) = 0;
         TIMER_DATA(i) = 0;
     }
+
+    // Setup exception handler
+#ifdef NDEBUG
+    releaseExceptionHandler();
+#else
+    defaultExceptionHandler();
+#endif
 
     // Clear video display registers
     dmaFillWords(0, (void *)0x04000000, 0x56);

--- a/source/common/libc/exit.c
+++ b/source/common/libc/exit.c
@@ -8,8 +8,13 @@
 #include <nds/fifocommon.h>
 #include <nds/system.h>
 
-#include "../fifo_ipc_messages.h"
-#include "../libnds_internal.h"
+#ifdef ARM9
+#include "arm9/libnds_internal.h"
+#else
+#include "arm7/libnds_internal.h"
+#endif
+#include "common/fifo_ipc_messages.h"
+#include "common/libnds_internal.h"
 
 extern char *fake_heap_end;
 
@@ -91,10 +96,5 @@ uintptr_t __stack_chk_guard = 0x00000aff;
 __attribute__((noreturn))
 THUMB_CODE void __stack_chk_fail(void)
 {
-    // This function causes an undefined instruction exception to crash the CPU
-    // in a controlled way.
-    //
-    // See common/libc/locks.c for more information.
-    asm volatile inline(".hword 0xE800 | 0xBAD");
-    __builtin_unreachable();
+    libndsCrash("Stack corrupted");
 }


### PR DESCRIPTION
- A new exception handler has been added to libnds. This is considered a release exception handler which will print a short message such as "Data abort" or "Stack corrupted" so that the user knows there has been a critical error and they can tell the developer. This is equivalent to the situation when you are running a Linux application and it prints "segmentation fault" when it crashes.

  This exception handler doesn't use printf(), which makes the code footprint of this handler a lot smaller than the current debug handler.

- libnds now sets up the exception handler before main(). It's a bad idea to ask users to enable the exception handler themselves because they will forget.

- A new crash handler has been added. When libnds detects a fatal error it can't recover from (and which makes continuing unsafe) it will use this handler to print a short error message and let the user know.

- Error handling in the ARM7 is still quite bad, we need to think about how to communicate errors to the ARM9.

- Also, this PR makes the tone of red of the exception handler a bit darker so that it contrasts more with the text on the screen.