### PR TITLE
libc: fix <unistd.h> not being included in syscalls.c

### DIFF
--- a/source/common/libc/syscalls.c
+++ b/source/common/libc/syscalls.c
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sys/times.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "../libnds_internal.h"
 


### PR DESCRIPTION
The latest updates to picolibc cleaned up headers a little, which means less stuff is implicitly included than before.