### PR TITLE
sound: Add sound capture helpers

### DIFF
--- a/include/nds/arm7/audio.h
+++ b/include/nds/arm7/audio.h
@@ -62,6 +62,23 @@ extern "C" {
 #define REG_SNDCAP0CNT      (*(vu8 *)0x04000508)
 #define REG_SNDCAP1CNT      (*(vu8 *)0x04000509)
 
+#define SND0CAPCNT_CH1_OUT_DIRECT       (0 << 0)
+#define SND0CAPCNT_CH1_OUT_ADD_TO_CH0   (1 << 0)
+#define SND0CAPCNT_SOURCE_LEFT_MIXER    (0 << 1)
+#define SND0CAPCNT_SOURCE_CH0           (1 << 1)
+
+#define SND1CAPCNT_CH3_OUT_DIRECT       (0 << 0)
+#define SND1CAPCNT_CH3_OUT_ADD_TO_CH2   (1 << 0)
+#define SND1CAPCNT_SOURCE_RIGHT_MIXER   (0 << 1)
+#define SND1CAPCNT_SOURCE_CH2           (1 << 1)
+
+#define SNDCAPCNT_REPEAT                (0 << 2)
+#define SNDCAPCNT_ONESHOT               (1 << 2)
+#define SNDCAPCNT_FORMAT_16BIT          (0 << 3)
+#define SNDCAPCNT_FORMAT_8BIT           (1 << 3)
+#define SNDCAPCNT_STOP                  (0 << 7)
+#define SNDCAPCNT_START_BUSY            (1 << 7)
+
 // The destination must be word-aligned, and the sizes are in words
 #define REG_SNDCAP0DAD      (*(vu32 *)0x04000510)
 #define REG_SNDCAP0LEN      (*(vu16 *)0x04000514)
@@ -175,7 +192,6 @@ static inline void micOff(void)
 {
     micSetAmp(PM_AMP_OFF, 0);
 }
-
 
 /// Set extended sound hardware frequency.
 ///

--- a/include/nds/arm9/sound.h
+++ b/include/nds/arm9/sound.h
@@ -31,6 +31,13 @@ typedef enum
     SoundFormat_ADPCM = 2  ///< IMA ADPCM compressed audio
 } SoundFormat;
 
+/// Sound formats used by the audio capture unit
+typedef enum
+{
+    SoundCaptureFormat_16Bit = 0, ///< 16-bit PCM
+    SoundCaptureFormat_8Bit = 1,  ///< 8-bit PCM
+} SoundCaptureFormat;
+
 /// Microphone recording formats DS
 typedef enum
 {
@@ -50,7 +57,6 @@ typedef enum
     DutyCycle_75 = 5, ///< 75.0% duty cycle
     DutyCycle_87 = 6  ///< 87.5% duty cycle
 } DutyCycle;
-
 
 /// Enables Sound on the DS.
 ///
@@ -256,6 +262,52 @@ void soundSetPan(int soundId, u8 pan);
 /// @param freq
 ///     The frequency in Hz.
 void soundSetFreq(int soundId, u16 freq);
+
+/// This starts a sound capture channel.
+///
+/// Audio capture channel 0 requires the frequency of sound channel 1 to be set
+/// with soundSetFreq(), for example. For audio capture channel 1, you need to
+/// do the same to sound channel 3. The sample rate of the capture circuit
+/// matches the one of its corresponding sound channel because the channels are
+/// the ones that can output the captured audio.
+///
+/// @param buffer
+///     Buffer to store the captured audio.
+/// @param bufferLen
+///     Size of the buffer in words. A value of 0 will be treated as 1.
+/// @param sndcapChannel
+///     The audio capture channel to use.
+/// @param addCapToChannel
+///     For audio capture channel 0:
+///     - If false, nothing special is done with the output of sound channel 1.
+///     - If true, the output of sound channel 1 is added to sound channel 0.
+///     For audio capture channel 1:
+///     - If false, nothing special is done with the output of sound channel 3.
+///     - If true, the output of sound channel 3 is added to sound channel 2.
+/// @param sourceIsMixer
+///     For audio capture channel 0:
+///     - If true, the capture source is the output of the left mixer.
+///     - If false, the capture source is sound channel 0.
+///     For audio capture channel 1:
+///     - If true, the capture source is the output of the right mixer.
+///     - If false, the capture source is sound channel 2.
+/// @param repeat
+///     If true, the capture will continue even after the buffer is full (it
+///     will go back to the start).
+/// @param format
+///     The audio format that will be used to store data in the provided buffer.
+///
+/// @returns
+///     It returns the capture channel index on success, -1 on error.
+int soundCaptureStart(void *buffer, u16 bufferLen, int sndcapChannel,
+                      bool addCapToChannel, bool sourceIsMixer, bool repeat,
+                      SoundCaptureFormat format);
+
+/// This stops a sound capture channel.
+///
+/// @param sndcapChannel
+///     The channel to stop.
+void soundCaptureStop(int sndcapChannel);
 
 /// Starts a microphone recording to a double buffer specified by buffer.
 ///

--- a/include/nds/fifomessages.h
+++ b/include/nds/fifomessages.h
@@ -20,6 +20,8 @@ typedef enum
     SOUND_PLAY_MESSAGE = 0x1234,
     SOUND_PSG_MESSAGE,
     SOUND_NOISE_MESSAGE,
+    SOUND_CAPTURE_START,
+    SOUND_CAPTURE_STOP,
     MIC_RECORD_MESSAGE,
     MIC_BUFFER_FULL_MESSAGE,
     SYS_INPUT_MESSAGE,
@@ -60,6 +62,17 @@ typedef struct FifoMessage
             u8 pan;
             s8 channel;
         } SoundPsg;
+
+        struct
+        {
+            void *buffer;
+            u16 bufferLen; // In words
+            u8 sndcapChannel;
+            u8 addCapToChannel; // Direct / add to channel N
+            u8 sourceIsMixer;   // Mixer / channel N
+            u8 repeat;
+            u8 format;
+        } SoundCaptureStart;
 
         struct
         {

--- a/source/arm9/sound.c
+++ b/source/arm9/sound.c
@@ -131,6 +131,37 @@ void soundSetWaveDuty(int soundId, DutyCycle cycle)
     fifoSendValue32(FIFO_SOUND, SOUND_SET_WAVEDUTY | (soundId << 16) | cycle);
 }
 
+int soundCaptureStart(void *buffer, u16 bufferLen, int sndcapChannel,
+                      bool addCapToChannel, bool sourceIsMixer, bool repeat,
+                      SoundCaptureFormat format)
+{
+    FifoMessage msg;
+
+    msg.type = SOUND_CAPTURE_START;
+    msg.SoundCaptureStart.buffer = buffer;
+    msg.SoundCaptureStart.bufferLen = bufferLen;
+    msg.SoundCaptureStart.sndcapChannel = sndcapChannel;
+    msg.SoundCaptureStart.addCapToChannel = addCapToChannel;
+    msg.SoundCaptureStart.sourceIsMixer = sourceIsMixer;
+    msg.SoundCaptureStart.repeat = repeat;
+    msg.SoundCaptureStart.format = format;
+
+    fifoMutexAcquire(FIFO_SOUND);
+
+    fifoSendDatamsg(FIFO_SOUND, sizeof(msg), (u8 *)&msg);
+    fifoWaitValue32Async(FIFO_SOUND);
+    int result = fifoGetValue32(FIFO_SOUND);
+
+    fifoMutexRelease(FIFO_SOUND);
+
+    return result;
+}
+
+void soundCaptureStop(int sndcapChannel)
+{
+    fifoSendValue32(FIFO_SOUND, SOUND_CAPTURE_STOP | (sndcapChannel << 16));
+}
+
 MicCallback micCallback = 0;
 
 void micBufferHandler(int bytes, void *user_data)


### PR DESCRIPTION
The sound capture can be used to capture the output of sound channels 0 and 2, or the output of the sound mixer to the left or right speakers. The captured audio can be saved to RAM or added to the output of sound channels 1 and 3.

While audio capture isn't as useful as video capture, it's still useful to have a way for users to take advantage of it without too much effort.

Audio capture channel 0 requires sound channel 1 to be active. The sample rate of the capture is taken from the sample rate of playback of channel 1 (so that it can be added to it if required). The same applies to audio capture channel 1 and sound channel 2.

The helpers in this patch only let the user setup the capture registers. Sound channels 1 and 3 must be setup by hand. The user may want to play the captured audio there, or it may want to silence it (by setting the volume to 0) and only use the values saved to RAM.