### PR TITLE
nitrofs: Block direct Slot-2 access for >32MB .nds files

### DIFF
--- a/source/arm9/libc/nitrofs.c
+++ b/source/arm9/libc/nitrofs.c
@@ -663,9 +663,10 @@ bool nitroFSInit(const char *basepath)
     {
         memcpy(nitrofs_offsets, &(__NDSHeader->filenameOffset), 4 * sizeof(uint32_t));
 
-        if (!isDSiMode())
+        // If not in DSi mode and the .nds file is <= 32MB...
+        if (!isDSiMode() && __NDSHeader->deviceSize <= 8)
         {
-            // If not reading from DLDI, we could still be reading from Slot-2.
+            // ... we could still be reading from Slot-2.
             // Figure this out by comparing NitroFS header data between the two.
             sysSetCartOwner(BUS_OWNER_ARM9);
             nitrofs_local.use_slot2 = !memcmp(((uint16_t *) 0x08000040), nitrofs_offsets, 4 * sizeof(uint32_t));


### PR DESCRIPTION
As a Slot-2 cartridge can have a maximum of 32MB of mapped address space, any .nds file over 32MB is guaranteed not to be fully accessible via this method. In particular, NO$GBA mounts the first 32MB of a .nds file in Slot-2, which caused NitroFS reads over the 32MB limit to be corrupted.