### PR TITLE
initSystem: Fix video register clearing ranges, remove redundant VRAM configuration

### DIFF
--- a/source/arm9/system/initSystem.c
+++ b/source/arm9/system/initSystem.c
@@ -48,8 +48,8 @@ void __attribute__((weak)) initSystem(void)
 #endif
 
     // Clear video display registers
-    dmaFillWords(0, (void *)0x04000000, 0x56);
-    dmaFillWords(0, (void *)0x04001008, 0x56);
+    dmaFillWords(0, (void *)0x04000000, 0x58);
+    dmaFillWords(0, (void *)0x04001008, 0x58 - 8);
 
     // Turn on power for 2D video
     REG_POWERCNT = (POWER_LCD | POWER_2D_A | POWER_2D_B | POWER_SWAP_LCDS) & 0xFFFF;
@@ -57,12 +57,6 @@ void __attribute__((weak)) initSystem(void)
     videoSetModeSub(0);
 
     vramDefault();
-
-    VRAM_E_CR = 0;
-    VRAM_F_CR = 0;
-    VRAM_G_CR = 0;
-    VRAM_H_CR = 0;
-    VRAM_I_CR = 0;
 
     if (isDSiMode())
         setCpuClock(true);

--- a/source/arm9/video/video.c
+++ b/source/arm9/video/video.c
@@ -72,8 +72,16 @@ u32 __attribute__((weak)) vramDefault(void)
     dmaFillWords(0, OAM, 2 * 1024);        // Clear main and sub OAM
     dmaFillWords(0, VRAM, 656 * 1024);     // Clear all VRAM
 
-    return vramSetPrimaryBanks(VRAM_A_MAIN_BG_0x06000000,
-                               VRAM_B_MAIN_SPRITE_0x06400000,
-                               VRAM_C_SUB_BG_0x06200000,
-                               VRAM_D_SUB_SPRITE_0x06600000);
+    u32 result = vramSetPrimaryBanks(VRAM_A_MAIN_BG_0x06000000,
+                                     VRAM_B_MAIN_SPRITE_0x06400000,
+                                     VRAM_C_SUB_BG_0x06200000,
+                                     VRAM_D_SUB_SPRITE_0x06600000);
+
+    VRAM_E_CR = 0;
+    VRAM_F_CR = 0;
+    VRAM_G_CR = 0;
+    VRAM_H_CR = 0;
+    VRAM_I_CR = 0;
+
+    return result;
 }


### PR DESCRIPTION
- Engine A was having just as many words cleared as engine B, despite engine B not clearing DISPCNT (due to `videoSetModeSub(0);` below - is this desired?
- `dmaFillWords` requires a multiple of 4; with `0x56`, the final register (`BLDY`) was not being cleared.
- Moved the clearing of VRAM banks E-I to `vramDefault();`, at least for now. Makes more sense for all the VRAM configuration to be in one place, to me - though most of the video configuration decisions don't make all that much sense to me at this stage.