### PR TITLE
cardEeprom, ndsmotion: clean up, fix bugs

### DIFF
--- a/include/nds.h
+++ b/include/nds.h
@@ -164,6 +164,7 @@ extern "C" {
 #    include <nds/arm9/keyboard.h>
 #    include <nds/arm9/linkedlist.h>
 #    include <nds/arm9/math.h>
+#    include <nds/arm9/ndsmotion.h>
 #    include <nds/arm9/paddle.h>
 #    include <nds/arm9/grf.h>
 #    include <nds/arm9/pcx.h>

--- a/include/nds/arm9/ndsmotion.h
+++ b/include/nds/arm9/ndsmotion.h
@@ -19,6 +19,14 @@
 extern "C" {
 #endif
 
+typedef enum
+{
+    MOTION_TYPE_NONE, ///< No sensor present
+    MOTION_TYPE_PAK, ///< DS Motion Pak
+    MOTION_TYPE_CARD, ///< DS Motion Card
+    MOTION_TYPE_MK6 ///< MK6
+} MotionType;
+
 typedef struct MotionCalibration
 {
     short xoff, yoff, zoff, goff;
@@ -32,7 +40,19 @@ typedef struct MotionCalibration
 ///
 /// @return
 ///     The motion sensor type, or 0 if there is no sensor present.
-int motion_init(void);
+MotionType motion_init(void);
+
+/// Get the type of the current initialized DS Motion Sensor.
+///
+/// @return
+///     The motion sensor type, or 0 if there is no sensor initialized or present.
+MotionType motion_get_type(void);
+
+/// Get the name of a given motion sensor type, or "None".
+///
+/// @return
+///     Pointer to the string. Don't call free() with this pointer.
+const char *motion_get_name(MotionType type);
 
 /// Deinitializes the DS Motion Sensor.
 void motion_deinit(void);
@@ -41,25 +61,25 @@ void motion_deinit(void);
 ///
 /// @return
 ///     The X acceleration.
-signed int motion_read_x(void);
+int motion_read_x(void);
 
 /// Reads the Y acceleration.
 ///
 /// @return
 ///     The Y acceleration.
-signed int motion_read_y(void);
+int motion_read_y(void);
 
 /// Reads the Z acceleration.
 ///
 /// @return
 ///     The Z acceleration.
-signed int motion_read_z(void);
+int motion_read_z(void);
 
 /// Reads the Z rotational speed.
 ///
 /// @return
 ///     The Z rotational speed.
-signed int motion_read_gyro(void);
+int motion_read_gyro(void);
 
 /// Gets acceleration value to mili G (where g is 9.8 m/s*s)
 ///

--- a/source/common/cardEeprom.c
+++ b/source/common/cardEeprom.c
@@ -13,7 +13,7 @@ u8 cardEepromCommand(u8 command)
 {
     u8 retval;
 
-    REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_ENABLE | CARD_SPI_ENABLE | CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 
     REG_AUXSPIDATA = command;
 
@@ -22,13 +22,13 @@ u8 cardEepromCommand(u8 command)
     REG_AUXSPIDATA = 0;
     eepromWaitBusy();
     retval = REG_AUXSPIDATA;
-    REG_AUXSPICNT = /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
     return retval;
 }
 
 u32 cardEepromReadID(void)
 {
-    REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_ENABLE | CARD_SPI_ENABLE | CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 
     REG_AUXSPIDATA = SPI_EEPROM_RDID;
 
@@ -42,7 +42,7 @@ u32 cardEepromReadID(void)
         id = (id << 8) | REG_AUXSPIDATA;
     }
 
-    REG_AUXSPICNT = /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 
     return id;
 }
@@ -181,7 +181,7 @@ uint32_t cardEepromGetSize(void)
 
 void cardReadEeprom(u32 address, u8 *data, u32 length, u32 addrtype)
 {
-    REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_ENABLE | CARD_SPI_ENABLE | CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
     REG_AUXSPIDATA = 0x03 | ((addrtype == 1) ? address >> 8 << 3 : 0);
     eepromWaitBusy();
 
@@ -209,7 +209,7 @@ void cardReadEeprom(u32 address, u8 *data, u32 length, u32 addrtype)
     }
 
     eepromWaitBusy();
-    REG_AUXSPICNT = /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 }
 
 void cardWriteEeprom(uint32_t address, uint8_t *data, uint32_t length, uint32_t addrtype)
@@ -229,13 +229,13 @@ void cardWriteEeprom(uint32_t address, uint8_t *data, uint32_t length, uint32_t 
     while (address < address_end)
     {
         // Set WEL (Write Enable Latch)
-        REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
+        REG_AUXSPICNT = CARD_ENABLE | CARD_SPI_ENABLE | CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
         REG_AUXSPIDATA = 0x06;
         eepromWaitBusy();
-        REG_AUXSPICNT = /*MODE*/ 0x40;
+        REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 
         // program maximum of 32 bytes
-        REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
+        REG_AUXSPICNT = CARD_ENABLE | CARD_SPI_ENABLE | CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 
         if (addrtype == 1)
         {
@@ -271,10 +271,10 @@ void cardWriteEeprom(uint32_t address, uint8_t *data, uint32_t length, uint32_t 
             REG_AUXSPIDATA = *data++;
             eepromWaitBusy();
         }
-        REG_AUXSPICNT = /*MODE*/ 0x40;
+        REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 
         // Wait programming to finish
-        REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
+        REG_AUXSPICNT = CARD_ENABLE | CARD_SPI_ENABLE | CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
         REG_AUXSPIDATA = 0x05;
         eepromWaitBusy();
         do
@@ -284,7 +284,7 @@ void cardWriteEeprom(uint32_t address, uint8_t *data, uint32_t length, uint32_t 
         } while (REG_AUXSPIDATA & 0x01); // WIP (Write In Progress) ?
 
         eepromWaitBusy();
-        REG_AUXSPICNT = /*MODE*/ 0x40;
+        REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
     }
 }
 
@@ -301,14 +301,14 @@ void cardEepromChipErase(void)
 void cardEepromSectorErase(uint32_t address)
 {
     // set WEL (Write Enable Latch)
-    REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_ENABLE | CARD_SPI_ENABLE | CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
     REG_AUXSPIDATA = 0x06;
     eepromWaitBusy();
 
-    REG_AUXSPICNT = /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 
     // SectorErase 0xD8
-    REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_ENABLE | CARD_SPI_ENABLE | CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
     REG_AUXSPIDATA = 0xD8;
     eepromWaitBusy();
     REG_AUXSPIDATA = (address >> 16) & 0xFF;
@@ -318,7 +318,7 @@ void cardEepromSectorErase(uint32_t address)
     REG_AUXSPIDATA = address & 0xFF;
     eepromWaitBusy();
 
-    REG_AUXSPICNT = /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 
     // wait erase to finish
     REG_AUXSPICNT = /*E*/ 0x8000 | /*SEL*/ 0x2000 | /*MODE*/ 0x40;
@@ -331,5 +331,5 @@ void cardEepromSectorErase(uint32_t address)
         eepromWaitBusy();
     } while (REG_AUXSPIDATA & 0x01); // WIP (Write In Progress) ?
 
-    REG_AUXSPICNT = /*MODE*/ 0x40;
+    REG_AUXSPICNT = CARD_SPI_HOLD | CARD_SPI_BAUD_4MHz;
 }


### PR DESCRIPTION
- Use AUXSPICNT macros instead of magic numbers for card SPI operations.
- Use Kionix macros instead of magic numbers for DS Motion Card SPI operations.
- Add motion_get_type() and motion_get_name() to the motion sensor driver.
- Clean up code duplication in the motion sensor driver.
- Fix motion sensor driver bugs:
  - Potentially fix DS Motion Card support in DSi mode.
  - Fix unnecessary DS card writes on deinitialization.
  - Fix analog input access causing unwanted GBA I/O when a DS card is detected.

The DS Motion Card proper may now work in DSi mode, but I don't have one to test; I have tested the MK6/R6, but that one seems to not communicate properly with a DSi/3DS at all.