### PR TITLE
LLVM and undefined behavior fixes

### DIFF
--- a/include/nds/arm7/aes.h
+++ b/include/nds/arm7/aes.h
@@ -41,7 +41,7 @@ typedef struct aes_keyslot
 
 #define AES_CNT_IRQ             (1 << 30)
 
-#define AES_CNT_ENABLE          (1 << 31)
+#define AES_CNT_ENABLE          (1u << 31)
 
 #define REG_AES_BLKCNT  (*(vu32 *)0x4004404)
 

--- a/include/nds/arm9/cp15_asm.h
+++ b/include/nds/arm9/cp15_asm.h
@@ -11,7 +11,7 @@
 // one even if they don't have a documented meaning.
 
 #ifndef BIT
-#define BIT(n)          (1 << (n))
+#define BIT(n)          (1u << (n))
 #endif
 
 // General definitions for the NDS

--- a/include/nds/arm9/video.h
+++ b/include/nds/arm9/video.h
@@ -586,9 +586,9 @@ typedef enum
 #define DISPLAY_SPR_1D_BMP_SIZE_256 (1 << 22)
 
 // Mask to clear all attributes related to sprites from display control
-#define DISPLAY_SPRITE_ATTR_MASK    ((7 << 4) | (7 << 20) | (1 << 31))
+#define DISPLAY_SPRITE_ATTR_MASK    ((7u << 4) | (7u << 20) | (1u << 31))
 
-#define DISPLAY_SPR_EXT_PALETTE     (1 << 31)
+#define DISPLAY_SPR_EXT_PALETTE     (1u << 31)
 #define DISPLAY_BG_EXT_PALETTE      (1 << 30)
 
 #define DISPLAY_SCREEN_OFF          (1 << 7)

--- a/include/nds/card.h
+++ b/include/nds/card.h
@@ -51,7 +51,7 @@ extern "C" {
 #define SPI_EEPROM_RDP  0xab // Release from deep power down
 #define SPI_EEPROM_DPD  0xb9 // Deep power down
 
-#define CARD_ACTIVATE     (1 << 31) // When writing, get the ball rolling
+#define CARD_ACTIVATE     (1u << 31) // When writing, get the ball rolling
 #define CARD_WR           (1 << 30) // Card write enable
 #define CARD_nRESET       (1 << 29) // Value on the /reset pin (1 = high out, not a reset state, 0 = low out = in reset)
 #define CARD_SEC_LARGE    (1 << 28) // Use "other" secure area mode, which tranfers blocks of 0x1000 bytes at a time
@@ -66,7 +66,7 @@ extern "C" {
 
 // 3 bits in b10..b8 indicate something
 // Read bits
-#define CARD_BUSY         (1 << 31) // When reading, still expecting incomming data?
+#define CARD_BUSY         (1u << 31) // When reading, still expecting incomming data?
 #define CARD_DATA_READY   (1 << 23) // When reading, CARD_DATA_RD or CARD_DATA has another word of data and is good to go
 
 // Card commands

--- a/include/nds/cpu_asm.h
+++ b/include/nds/cpu_asm.h
@@ -8,7 +8,7 @@
 // This file must only have definitions that can be used from assembly files.
 
 #ifndef BIT
-#define BIT(n) (1 << (n))
+#define BIT(n) (1u << (n))
 #endif
 
 #define CPSR_MODE_MASK          (0x1F)

--- a/include/nds/ndstypes.h
+++ b/include/nds/ndstypes.h
@@ -76,7 +76,7 @@ extern "C" {
 #define GETRAWEND(name)     ((int)name##_end)
 
 /// Returns a number with the nth bit set.
-#define BIT(n) (1 << (n))
+#define BIT(n) (1u << (n))
 
 // Deprecated types. TODO: Remove
 typedef uint8_t uint8;

--- a/source/arm7/libnds_internal.h
+++ b/source/arm7/libnds_internal.h
@@ -30,7 +30,7 @@ libnds_touchMeasurementFilterResult libnds_touchMeasurementFilter(u16 values[5])
 __attribute__((always_inline, noreturn))
 THUMB_CODE static inline void libndsCrash(__attribute__((unused)) const char *message)
 {
-    asm volatile("udf" ::: "memory");
+    asm volatile("udf #0" ::: "memory");
     while (1);
 }
 

--- a/source/arm9/math.c
+++ b/source/arm9/math.c
@@ -40,7 +40,7 @@ ARM_CODE float hw_sqrtf(float x)
     // It is critical that this happens as early as possible so that
     // we have time to do other stuff in the meantime
     u32 raw_exponent = xu.i & (255 << 23);
-    u32 sign = xu.i & (1 << 31);
+    u32 sign = xu.i & (1u << 31);
     // check if exponent is 0
     if (raw_exponent != 0)
     {

--- a/source/arm9/system/gurumeditation.c
+++ b/source/arm9/system/gurumeditation.c
@@ -441,7 +441,7 @@ void libndsCrash(const char *msg)
     exceptionMsg = msg;
 
     // Use an undefined instruction defined by the assembler
-    asm volatile("udf" ::: "memory");
+    asm volatile("udf #0" ::: "memory");
 
     while (1);
 }

--- a/source/arm9/system/gurumeditation.c
+++ b/source/arm9/system/gurumeditation.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include <nds/arm9/background.h>
 #include <nds/arm9/console.h>
@@ -338,7 +339,7 @@ void guruMeditationDump(void)
     {
         // Finally, print everything to the screen
 
-        printf("  pc: %08lX addr: %08lX\n\n", codeAddress, exceptionAddress);
+        printf("  pc: %08" PRIX32 " addr: %08" PRIX32 "\n\n", codeAddress, exceptionAddress);
 
         for (int i = 0; i < 8; i++)
         {
@@ -348,7 +349,7 @@ void guruMeditationDump(void)
                 "r8 ", "r9 ", "r10", "r11", "r12", "sp ", "lr ", "pc "
             };
 
-            printf("  %s: %08lX   %s: %08lX\n",
+            printf("  %s: %08" PRIX32 "   %s: %08" PRIX32 "\n",
                    registerNames[i], exceptionRegisters[i],
                    registerNames[i + 8], exceptionRegisters[i + 8]);
         }
@@ -358,8 +359,8 @@ void guruMeditationDump(void)
         for (int i = 0; i < 10; i++)
         {
             consoleSetCursor(NULL, 2, i + 14);
-            printf("%08lX:  %08lX %08lX", (u32)&stack[i * 2],
-                   stack[i * 2], stack[(i * 2) + 1]);
+            printf("%08" PRIX32 ":  %08" PRIX32 " %08" PRIX32 "",
+                   (u32)&stack[i * 2], stack[i * 2], stack[(i * 2) + 1]);
         }
     }
 

--- a/source/arm9/video/sprite.c
+++ b/source/arm9/video/sprite.c
@@ -229,7 +229,9 @@ void oamSet(OamState *oam, int id, int x, int y, int priority, int palette_alpha
     else
     {
         oam->oamMemory[id].blendMode = OBJMODE_NORMAL;
-        oam->oamMemory[id].colorMode = format;
+        // SpriteColorFormat is identical to ObjColMode except for
+        // SpriteColorFormat_Bmp, checked for above
+        oam->oamMemory[id].colorMode = (ObjColMode)format;
         oam->oamMemory[id].palette = palette_alpha;
     }
 }
@@ -254,7 +256,9 @@ void oamSetGfx(OamState *oam, int id, SpriteSize size, SpriteColorFormat format,
     else
     {
         oam->oamMemory[id].blendMode = OBJMODE_NORMAL;
-        oam->oamMemory[id].colorMode = format;
+        // SpriteColorFormat is identical to ObjColMode except for
+        // SpriteColorFormat_Bmp, checked for above
+        oam->oamMemory[id].colorMode = (ObjColMode)format;
     }
 }
 


### PR DESCRIPTION
* Add an immediate value (0) to `udf` instructions, as it is required for LLVM and optional with GCC
* Fix signed overflow from `1 << 31`
* Proper printf format string in gurumeditation (fixes warnings)
* Change an implicit enum cast to explicit, with a comment explaining why it is valid

The only other error/warning still in LLVM 19 is the following:

```c
libnds/source/common/libc/sbrk.c:43:20: error: variable 'stack_ptr' is uninitialized when used here
        heap_end = stack_ptr;
                   ^
libnds/source/common/libc/sbrk.c:25:33: note: initialize the variable 'stack_ptr' to silence this warning
    register uintptr_t stack_ptr asm("sp");
                                ^
```

It seems like GCC's `register` keyword is explicitly not intended to be used the way it is in sbrk.

From https://gcc.gnu.org/onlinedocs/gcc/Local-Register-Variables.html:

> The only supported use for this feature is to specify registers for input and output operands when calling Extended asm

It could potentially be replaced with an inline assembly `mov` like this:

```diff
diff --git a/source/common/libc/sbrk.c b/source/common/libc/sbrk.c
index bb818ed..fc75feb 100644
--- a/source/common/libc/sbrk.c
+++ b/source/common/libc/sbrk.c
@@ -22,7 +22,8 @@ void *sbrk(int incr)
     const uintptr_t end = (uintptr_t)__end__;
 
     // Trick to get the current stack pointer
-    register uintptr_t stack_ptr asm("sp");
+    uintptr_t stack_ptr;
+    asm ("mov %0, sp" : "=r" (stack_ptr) );
 
     // Next address to be used. It is updated after every call to sbrk()
     static uintptr_t heap_start = 0;
```

However I am not sure of the semantics are correct, and GCC produces different code, so I didn't include it as part of this PR.