### PR TITLE
cache, diskio: Optimizations and bugfixes.

### DIFF
--- a/source/arm9/libc/fatfs/cache.h
+++ b/source/arm9/libc/fatfs/cache.h
@@ -13,4 +13,13 @@ void *cache_sector_get(uint8_t pdrv, uint32_t sector);
 void *cache_sector_add(uint8_t pdrv, uint32_t sector);
 void cache_sector_invalidate(uint8_t pdrv, uint32_t sector_from, uint32_t sector_to);
 
+/**
+ * "Borrow" an unused cache entry to use as a write buffer.
+ */
+__attribute__((always_inline))
+static inline void *cache_sector_borrow(void)
+{
+    return cache_sector_add(0xFF, 0);
+}
+
 #endif // FATFS_CACHE_H__


### PR DESCRIPTION
- Fix cache invalidation not invalidating more than one sector per call.
- Replaced cache algorithm with a simple LRU; appears to perform better with simpler code, but more benchmarking/research should be done.
- Removed the malloc() call in disk_write(), replacing it with "borrowing" a slot from the LRU cache without marking it valid.
- Adjusted disk_read() similarly, so that sectors marked as not to be cached do not generate cache requires.
- Added additional debugging defines to diskio.c.