### PR TITLE
Let glColorTableEXT allocate VRAM without filling

### DIFF
--- a/include/nds/arm9/videoGL.h
+++ b/include/nds/arm9/videoGL.h
@@ -503,8 +503,8 @@ static inline enum GL_TEXTURE_SIZE_ENUM glTexSizeToEnum(int size)
 /// @param empty3
 ///     Ignored, only here for OpenGL compatibility.
 /// @param table
-///     Pointer to the palette data to load (if NULL, the palette is removed
-///     from currently bound texture).
+///     Pointer to the palette data to load. If this is NULL, the palette will
+///     be allocated but no data will be copied to it.
 ///
 /// @return
 ///     1 on success, 0 on failure.

--- a/source/arm9/video/videoGL.c
+++ b/source/arm9/video/videoGL.c
@@ -1450,9 +1450,9 @@ int glColorTableEXT(int target, int empty1, uint16_t width, int empty2, int empt
     if (texture->palIndex) // Remove prior palette if exists
         removePaletteFromTexture(texture);
 
-    // Exit if no color table or color count is 0 (helpful in emptying the
-    // palette for the active texture). This isn't considered an error.
-    if ((width == 0) || (table == NULL))
+    // Exit if color count is 0 (helpful in emptying the palette for the active texture).
+    // This isn't considered an error.
+    if (width == 0)
         return 1;
 
     // Allocate new palette block based on the texture's format
@@ -1534,6 +1534,14 @@ int glColorTableEXT(int target, int empty1, uint16_t width, int empty2, int empt
     palette->connectCount = 1;
     palette->palSize = width << 1;
 
+    GFX_PAL_FORMAT = palette->addr;
+    glGlob.activePalette = texture->palIndex;
+
+    // Exit if table is NULL (helpful to allocate VRAM without filling).
+    // This isn't considered an error.
+    if (table == NULL)
+        return 1;
+
     // Copy straight to VRAM, and assign a palette name
     uint32_t tempVRAM = VRAM_EFG_CR;
     uint16_t *startBank = vramGetBank((uint16_t *)palette->vramAddr);
@@ -1559,9 +1567,6 @@ int glColorTableEXT(int target, int empty1, uint16_t width, int empty2, int empt
 
     swiCopy(table, palette->vramAddr, width | COPY_MODE_HWORD);
     vramRestoreBanks_EFG(tempVRAM);
-
-    GFX_PAL_FORMAT = palette->addr;
-    glGlob.activePalette = texture->palIndex;
 
     return 1;
 }


### PR DESCRIPTION
We briefly discussed this over Discord around an hour ago.

This change is necessary to allow allocating a palette while the 3D engine is active without causing VRAM corruption.

I've been using a similar change (as a separate function built with my program) successfully for months, and have tested this change as performing equivalently to my earlier version.