### PR TITLE
Add ARM7 exception handler that sends the crash dump to the ARM9

### DIFF
--- a/include/nds/exceptions.h
+++ b/include/nds/exceptions.h
@@ -54,7 +54,6 @@ void enterException(void);
 ///     Exception handler routine.
 void setExceptionHandler(VoidFn handler);
 
-#ifdef ARM9
 /// Sets the default debug hardware exception handler.
 ///
 /// This handler prints a lot of information, like the state of the CPU
@@ -66,7 +65,6 @@ void defaultExceptionHandler(void);
 /// This is similar to defaultExceptionHandler(), but it only prints a minimal
 /// error message, and it uses a lot less code to do it.
 void releaseExceptionHandler(void);
-#endif
 
 #ifdef __cplusplus
 }

--- a/include/nds/fifocommon.h
+++ b/include/nds/fifocommon.h
@@ -70,6 +70,7 @@ typedef enum
     SYS_SET_TIME, // TODO: Unused
     SDMMC_INSERT, // TODO: Unused
     SDMMC_REMOVE, // TODO: Unused
+    SYS_ARM7_CRASH,
 } FifoSystemCommands;
 
 typedef enum

--- a/source/arm7/exceptions.c
+++ b/source/arm7/exceptions.c
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Zlib
+// SPDX-FileNotice: Modified from the original version by the BlocksDS project.
+//
+// Copyright (C) 2005 Dave Murphy (WinterMute)
+// Copyright (c) 2024 Antonio Niño Díaz
+
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include <nds/exceptions.h>
+#include <nds/cpu_asm.h>
+#include <nds/fifocommon.h>
+#include <nds/interrupts.h>
+#include <nds/ipc.h>
+#include <nds/memory.h>
+#include <nds/ndstypes.h>
+#include <nds/system.h>
+
+#include "common/fifo_ipc_messages.h"
+#include "common/libnds_internal.h"
+
+__attribute__((noreturn))
+void guruMeditationDump(void)
+{
+    REG_IME = 0;
+
+    __TransferRegion volatile *ipc = __transferRegion();
+    ExceptionState *ex = (ExceptionState *)&ipc->exceptionState;
+
+    // Clear everything in case some fields are left empty
+    memset(ex, 0, sizeof(ExceptionState));
+
+    // The current CPU mode specifies whether the exception was caused by a data
+    // abort or an undefined instruction.
+    u32 currentMode = getCPSR() & CPSR_MODE_MASK;
+
+    // Check the location where the BIOS stored the CPSR state at the moment of
+    // the exception.
+    u32 thumbState = *(EXCEPTION_STACK_TOP - 3) & CPSR_FLAG_T;
+
+    u32 codeAddress = 0, exceptionAddress = 0;
+
+    // TODO: Check that offsets are correct
+    int offset = 8;
+
+    bool dump_state = false;
+
+    if (exceptionMsg != NULL)
+    {
+        strcpy(ex->description, exceptionMsg);
+
+        // This should have happened because of an undefined instruction, get
+        // information the same way.
+        if (thumbState)
+            offset = 2;
+        else
+            offset = 4;
+
+        codeAddress = exceptionRegisters[15] - offset;
+        exceptionAddress = codeAddress;
+
+        dump_state = true;
+    }
+    else
+    {
+        if (currentMode == CPSR_MODE_ABORT)
+        {
+            strcpy(ex->description, "Data abort!");
+
+            // This should never happen on the ARM7.
+        }
+        else if (currentMode == CPSR_MODE_UNDEFINED)
+        {
+            strcpy(ex->description, "Undefined instruction");
+
+            // Get the address where the exception was triggered, which is the
+            // one that holds the undefined instruction, so it's the same
+            // address as the exception address.
+
+            // That PC will have advanced one instruction, so the actual
+            // location of the undefined instruction is one instruction before
+            // the current PC.
+            if (thumbState)
+                offset = 2;
+            else
+                offset = 4;
+
+            codeAddress = exceptionRegisters[15] - offset;
+            exceptionAddress = codeAddress;
+
+            dump_state = true;
+        }
+        else
+        {
+            strcpy(ex->description, "Unknown error");
+
+            // If we're here because of an unknown error we can't get any useful
+            // information.
+        }
+    }
+
+    if (dump_state)
+    {
+        // Finally, save everything to IPC memory
+
+        memcpy(&(ex->reg[0]), &(exceptionRegisters[0]), sizeof(ex->reg));
+
+        ex->reg[15] = codeAddress;
+        ex->address = exceptionAddress;
+
+        u32 *stack = (u32 *)exceptionRegisters[13];
+        for (int i = 0; i < 10; i++)
+        {
+            ex->stack[(i * 2) + 0] = stack[(i * 2) + 0];
+            ex->stack[(i * 2) + 1] = stack[(i * 2) + 1];
+        }
+    }
+
+    // We can't trust the FIFO library at this point. The best we can do is wait
+    // until the send FIFO isn't full and send a packet writing to the registers
+    // themselves. fifoSendValue32(FIFO_SYSTEM, SYS_ARM7_CRASH) wouldn't be
+    // reliable.
+
+    while (REG_IPC_FIFO_CR & IPC_FIFO_SEND_FULL)
+        ;
+
+    REG_IPC_FIFO_TX = fifo_ipc_pack_value32(FIFO_SYSTEM, SYS_ARM7_CRASH);
+
+    // We can't make any assumption about what happened before an exception. It
+    // may have happened when dereferencing a NULL pointer before doing any
+    // harm, or it may happen because of a corrupted return address after a
+    // stack overflow.
+    //
+    // In any case, we can't assume that the exit-to-loader code hasn't been
+    // corrupted, so it's a good idea to wait here forever.
+    //
+    // By disabling interrupts and calling swiWaitForVBlank() we will get into a
+    // low power mode while the CPU waits forever.
+
+    while (1)
+        swiWaitForVBlank();
+}
+
+__attribute__((noreturn))
+static void defaultHandler(void)
+{
+    guruMeditationDump();
+}
+
+void defaultExceptionHandler(void)
+{
+    setExceptionHandler(defaultHandler);
+}
+
+// ---------------------------------------
+
+__attribute__((noreturn))
+static void releaseCrashHandler(void)
+{
+    REG_IME = 0;
+
+    const char *msg = exceptionMsg;
+
+    if (msg == NULL)
+    {
+        // If there is no message, try to determine the reason for the crash.
+        // The current CPU mode specifies whether the exception was caused by a
+        // data abort or an undefined instruction.
+        u32 currentMode = getCPSR() & CPSR_MODE_MASK;
+        if (currentMode == CPSR_MODE_ABORT)
+            msg = "Data abort";
+        else if (currentMode == CPSR_MODE_UNDEFINED)
+            msg = "Undefined instruction";
+        else
+            msg = "Unknown error";
+    }
+
+    __TransferRegion volatile *ipc = __transferRegion();
+    ExceptionState *ex = (ExceptionState *)&(ipc->exceptionState);
+
+    strcpy(ex->description, msg);
+
+    while (REG_IPC_FIFO_CR & IPC_FIFO_SEND_FULL)
+        ;
+
+    REG_IPC_FIFO_TX = fifo_ipc_pack_value32(FIFO_SYSTEM, SYS_ARM7_CRASH);
+
+    while (1)
+        swiWaitForVBlank();
+}
+
+void releaseExceptionHandler(void)
+{
+    setExceptionHandler(releaseCrashHandler);
+}

--- a/source/arm9/system/exceptions.c
+++ b/source/arm9/system/exceptions.c
@@ -106,7 +106,7 @@ void guruMeditationDump(void)
     {
         if (currentMode == CPSR_MODE_ABORT)
         {
-            strcpy(ex.description, "Data abort!");
+            strcpy(ex.description, "Data abort");
 
             // In a data abort, there is an instruction that tried to access an
             // invalid address, and an invalid address.
@@ -140,7 +140,7 @@ void guruMeditationDump(void)
         }
         else if (currentMode == CPSR_MODE_UNDEFINED)
         {
-            strcpy(ex.description, "Undefined instruction!");
+            strcpy(ex.description, "Undefined instruction");
 
             // Get the address where the exception was triggered, which is the
             // one that holds the undefined instruction, so it's the same
@@ -159,7 +159,7 @@ void guruMeditationDump(void)
         }
         else
         {
-            strcpy(ex.description, "Unknown error!");
+            strcpy(ex.description, "Unknown error");
 
             // If we're here because of an unknown error we can't print anything
             print_information = false;

--- a/source/arm9/system/system.c
+++ b/source/arm9/system/system.c
@@ -13,6 +13,7 @@
 #include <nds/system.h>
 
 #include "arm9/libnds_internal.h"
+#include "common/libnds_internal.h"
 
 static void (*SDcallback)(int) = NULL;
 
@@ -39,6 +40,17 @@ void systemValueHandler(u32 value, void *data)
             if (SDcallback)
                 SDcallback(0);
             break;
+        case SYS_ARM7_CRASH:
+        {
+            REG_IME = 0;
+
+            __TransferRegion volatile *ipc = __transferRegion();
+            ExceptionState *ex = (ExceptionState *)&ipc->exceptionState;
+            exceptionStatePrint(ex, "ARM7 Guru Meditation Error");
+
+            while (1)
+                swiWaitForVBlank();
+        }
     }
 }
 

--- a/source/common/libnds_internal.h
+++ b/source/common/libnds_internal.h
@@ -27,6 +27,7 @@ typedef struct __TransferRegion
 {
     time_t unixTime;
     struct __bootstub *bootcode;
+    ExceptionState exceptionState;
 } __TransferRegion, *__pTransferRegion;
 
 static_assert(sizeof(__TransferRegion) <= 0x1000, "Transfer region is too big");

--- a/source/common/libnds_internal.h
+++ b/source/common/libnds_internal.h
@@ -16,6 +16,13 @@
 #include <nds/ndstypes.h>
 #include <nds/system.h>
 
+typedef struct {
+    uint32_t reg[16]; // State of user CPU registers
+    uint32_t address; // Address that was accessed and caused the exception
+    uint32_t stack[22]; // Dump of the stack at the SP
+    char description[32]; // Reason for the exception
+} ExceptionState;
+
 typedef struct __TransferRegion
 {
     time_t unixTime;
@@ -74,5 +81,7 @@ extern const char *exceptionMsg;
 
 uint32_t ARMShift(uint32_t value, uint8_t shift);
 u32 getExceptionAddress(u32 opcodeAddress, u32 thumbState);
+
+void exceptionStatePrint(ExceptionState *ex, const char *title);
 
 #endif // COMMON_LIBNDS_INTERNAL_H__


### PR DESCRIPTION
This PR adds an exception handler that the user needs to enable. When the exception handler is executed, it saves a crash dump in the IPC shared memory and sends a FIFO message to the ARM9 to notify it so that it can print it (the same way it prints ARM9 crash dumps). Note that the FIFO message is just one packet that is sent without using the FIFO library so that the process is more robust.

It also splits the ARM9 exception handler so that it can reuse the printing code for ARM9 and ARM7 crashes.