### PR TITLE
Add initial version of the ARM7 console

### DIFF
--- a/include/nds.h
+++ b/include/nds.h
@@ -99,6 +99,7 @@
 ///
 /// @section arm7 ARM7 modules
 /// - @ref nds/arm7/clock.h "RTC utilities"
+/// - @ref nds/arm7/console.h "Console to that sends messages to the ARM9 easily"
 /// - @ref nds/arm7/input.h "Keypad and touch pad ARM7 helpers"
 /// - @ref nds/arm7/audio.h "Audio and microphone helpers"
 /// - @ref nds/arm7/touch.h "Touch screen helpers"
@@ -193,6 +194,7 @@ extern "C" {
 #    include <nds/arm7/camera.h>
 #    include <nds/arm7/clock.h>
 #    include <nds/arm7/codec.h>
+#    include <nds/arm7/console.h>
 #    include <nds/arm7/firmware.h>
 #    include <nds/arm7/gpio.h>
 #    include <nds/arm7/i2c.h>

--- a/include/nds/arm7/console.h
+++ b/include/nds/arm7/console.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2024 Antonio Niño Díaz
+
+#ifndef LIBNDS_NDS_ARM7_CONSOLE_H__
+#define LIBNDS_NDS_ARM7_CONSOLE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @file nds/arm7/console.h
+///
+/// @brief API to send console messages to the ARM9 from the ARM7.
+///
+/// You need to setup this console by calling consoleArm7Setup() on the ARM9.
+
+#include <stdbool.h>
+
+/// Checks if the console has been setup by the ARM9 or not.
+///
+/// @return
+///     Returns true if the console is setup, false if not.
+bool consoleIsSetup(void);
+
+/// Adds a character to the ring buffer to be printed.
+///
+/// If the buffer is full, this function will send a flush command to the ARM9
+/// and it will wait until there is space to add a new character.
+///
+/// @param c
+///     Character to be printed.
+///
+/// @return
+///     It returns 0 on success, or an error code if the console hasn't been
+///     initialized.
+int consolePrintChar(char c);
+
+/// Sends a message to the ARM9 to print the contents stored in the buffer.
+void consoleFlush(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LIBNDS_NDS_ARM7_CONSOLE_H__
+

--- a/include/nds/arm7/console.h
+++ b/include/nds/arm7/console.h
@@ -36,6 +36,36 @@ bool consoleIsSetup(void);
 ///     initialized.
 int consolePrintChar(char c);
 
+/// Adds an unsigned integer to the ring buffer to be printed.
+///
+/// @param num
+///     Unsigned integer to be printed.
+/// @param base
+///     Base of the number to be used (normally 10 or 16, max is 16).
+void consolePrintNumUnsigned(uint32_t num, uint32_t base);
+
+/// Adds a string to the ring buffer to be printed.
+///
+/// @param str
+///     String to be printed.
+void consolePuts(const char *str);
+
+/// It adds a formatted string to the buffer.
+///
+/// This version is a super minimalistic printf(). Supported flags:
+/// - %c: Character.
+/// - $d: Signed decimal 32-bit integer.
+/// - %s: String.
+/// - $u: Unsigned decimal 32-bit integer.
+/// - %x: Hexadecimal 32-bit integer.
+///
+/// @param fmt
+///     Formatted string.
+///
+/// @return
+///     It returns 0 on success, -1 if there are unsuported flags.
+int consolePrintf(const char *fmt, ...) __printflike(1, 2);
+
 /// Sends a message to the ARM9 to print the contents stored in the buffer.
 void consoleFlush(void);
 

--- a/include/nds/arm9/console.h
+++ b/include/nds/arm9/console.h
@@ -468,6 +468,38 @@ void consoleSetCustomStdout(ConsoleOutFn fn);
 ///     Callback where stderr is sent.
 void consoleSetCustomStderr(ConsoleOutFn fn);
 
+/// Initialize the ARM7 console and direct the output to the specified console.
+///
+/// This function allocates a ring buffer in main RAM and shares the pointer
+/// with the ARM7. The ARM7 will start saving text to this buffer and the ARM9
+/// is in charge of reading the buffer and sending it to the desired
+/// PrintConsole.
+///
+/// @param console
+///     Console that will receive the text from the ARM7. This must have been
+///     initialized with consoleInit() or similar functions.
+/// @param buffer_size
+///     Size of the shared buffer.
+///
+/// @return
+///     On success, it returns 0. On failure, a negative number. This can happen
+///     if the buffer is already setup or if there isn't enough space in the
+///     heap. Please, call consoleArm7Disable() first if you want to change the
+///     size of the buffer.
+int consoleArm7Setup(PrintConsole *console, size_t buffer_size);
+
+/// It disables the ARM7 console and frees the shared buffer.
+///
+/// @return
+///     It reutrns 0 on success, an error code otherwise.
+int consoleArm7Disable(void);
+
+/// This function checks the ring buffer and prints all enqueued text.
+///
+/// This function doesn't need to be called normally, this is requested by the
+/// ARM7 whenever it is required.
+void consoleArm7Flush(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/nds/fifocommon.h
+++ b/include/nds/fifocommon.h
@@ -71,6 +71,8 @@ typedef enum
     SDMMC_INSERT, // TODO: Unused
     SDMMC_REMOVE, // TODO: Unused
     SYS_ARM7_CRASH,
+    SYS_ARM7_CONSOLE_FLUSH,
+    SYS_SET_ARM7_CONSOLE,
 } FifoSystemCommands;
 
 typedef enum

--- a/include/nds/fifomessages.h
+++ b/include/nds/fifomessages.h
@@ -115,6 +115,10 @@ typedef struct FifoMessage {
             u16 value;
             u8 device;
         } aptRegParams;
+
+        struct {
+            void *buffer;
+        } setArm7Console;
     };
 
 } ALIGN(4) FifoMessage;

--- a/source/arm7/console.c
+++ b/source/arm7/console.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2024 Antonio Niño Díaz
+
+#include <stdio.h>
+
+#include <nds/arm7/console.h>
+#include <nds/bios.h>
+#include <nds/fifocommon.h>
+
+#include "common/libnds_internal.h"
+
+static ConsoleArm7Ipc *con = NULL;
+
+// This is an internal libnds function called by the FIFO handler when the ARM9
+// sets up the ARM7 console system.
+int consoleSetup(ConsoleArm7Ipc *c)
+{
+    con = c;
+
+    return 0;
+}
+
+bool consoleIsSetup(void)
+{
+    if (con == NULL)
+        return false;
+
+    return true;
+}
+
+static uint16_t consoleNextWriteIndex(ConsoleArm7Ipc *c)
+{
+    if (c->write_index + 1 >= c->buffer_size)
+        return 0;
+    else
+        return c->write_index + 1;
+}
+
+bool consoleIsFull(void)
+{
+    uint16_t next_write_index = consoleNextWriteIndex(con);
+
+    if (next_write_index == con->read_index)
+        return true;
+
+    return false;
+}
+
+int consolePrintChar(char c)
+{
+    if (con == NULL)
+        return -1;
+
+    if (consoleIsFull())
+    {
+        consoleFlush();
+
+        do
+        {
+            // Give some time to the ARM9 to print more than one character so
+            // that we don't send too many FIFO commands. It's a lot faster to
+            // add characters from the ARM7 than to print them from the ARM9.
+            swiDelay(100);
+        }
+        while (consoleIsFull());
+    }
+
+    con->buffer[con->write_index] = c;
+    con->write_index++;
+
+    if (con->write_index == con->buffer_size)
+        con->write_index = 0;
+
+    return 0;
+}
+
+void consoleFlush(void)
+{
+    fifoSendValue32(FIFO_SYSTEM, SYS_ARM7_CONSOLE_FLUSH);
+}

--- a/source/arm7/libnds_internal.h
+++ b/source/arm7/libnds_internal.h
@@ -8,6 +8,8 @@
 
 #include <nds/ndstypes.h>
 
+#include "common/libnds_internal.h"
+
 void storageMsgHandler(int bytes, void *user_data);
 void storageValueHandler(u32 value, void *user_data);
 void firmwareMsgHandler(int bytes, void *user_data);
@@ -24,5 +26,7 @@ typedef struct {
  * Internal. See touchFilter.c for more information.
  */
 libnds_touchMeasurementFilterResult libnds_touchMeasurementFilter(u16 values[5]);
+
+int consoleSetup(ConsoleArm7Ipc *c);
 
 #endif // ARM7_LIBNDS_INTERNAL_H__

--- a/source/arm7/system.c
+++ b/source/arm7/system.c
@@ -4,8 +4,10 @@
 // Copyright (C) 2005 Michael Noland (joat)
 // Copyright (C) 2005-2008 Jason Rogers (Dovoto)
 // Copyright (C) 2009-2017 Dave Murphy (WinterMute)
+// Copyright (C) 2024 Antonio Niño Díaz
 
 #include <nds/arm7/clock.h>
+#include <nds/arm7/console.h>
 #include <nds/arm7/i2c.h>
 #include <nds/arm7/sdmmc.h>
 #include <nds/arm7/tmio.h>
@@ -165,10 +167,27 @@ int sleepEnabled(void)
     return sleepIsEnabled;
 }
 
+void systemMsgHandler(int bytes, void *user_data)
+{
+    (void)user_data;
+
+    FifoMessage msg;
+
+    fifoGetDatamsg(FIFO_SYSTEM, bytes, (u8 *)&msg);
+
+    switch (msg.type)
+    {
+        case SYS_SET_ARM7_CONSOLE:
+            consoleSetup(msg.setArm7Console.buffer);
+            break;
+    }
+}
+
 void installSystemFIFO(void)
 {
     fifoSetValue32Handler(FIFO_PM, powerValueHandler, 0);
     fifoSetValue32Handler(FIFO_STORAGE, storageValueHandler, 0);
     fifoSetDatamsgHandler(FIFO_STORAGE, storageMsgHandler, 0);
     fifoSetDatamsgHandler(FIFO_FIRMWARE, firmwareMsgHandler, 0);
+    fifoSetDatamsgHandler(FIFO_SYSTEM, systemMsgHandler, 0);
 }

--- a/source/arm9/system/system.c
+++ b/source/arm9/system/system.c
@@ -51,6 +51,9 @@ void systemValueHandler(u32 value, void *data)
             while (1)
                 swiWaitForVBlank();
         }
+        case SYS_ARM7_CONSOLE_FLUSH:
+            consoleArm7Flush();
+            break;
     }
 }
 

--- a/source/common/libnds_internal.h
+++ b/source/common/libnds_internal.h
@@ -80,6 +80,15 @@ u32 getExceptionAddress(u32 opcodeAddress, u32 thumbState);
 
 void exceptionStatePrint(ExceptionState *ex, const char *title);
 
+// ARM7 debug console
+
+typedef struct {
+    uint16_t buffer_size; // This limits the size of the buffer to 64 KiB
+    uint16_t read_index;
+    uint16_t write_index;
+    char buffer[];
+} ConsoleArm7Ipc;
+
 // Other functions present in the ARM7 and ARM9
 
 void __libnds_exit(int rc);


### PR DESCRIPTION
The ARM9 allocates a ring buffer in main RAM. This buffer is passed to the ARM7, which then can start writing text to it. The ARM7 needs to notify the ARM9 when new text is added to the buffer so that the ARM9 can print it and empty the buffer.

The system is connected to the current ARM9 console system, so the output of this console can be any PrintConsole in use by the ARM9. For example, it is possible to start one console on the top screen and let the ARM9 use it while there is another console on the bottom screen that is used to print whatever the ARM7 prints.

A custom versions of `puts()` has been implemented, as well as a minimal version of printf(). ARM7 binaries don't have a lot of space to play with, so it's a generally a bad idea to use the regular printf() there.

It's still possible to use snprintf() from libc instead of this minimal version of printf() if more complex formats are required.
