### PR TITLE
console: include used headers directly

### DIFF
--- a/include/nds/arm7/console.h
+++ b/include/nds/arm7/console.h
@@ -16,6 +16,7 @@ extern "C" {
 /// You need to setup this console by calling consoleArm7Setup() on the ARM9.
 
 #include <stdbool.h>
+#include <sys/cdefs.h>
 
 /// Checks if the console has been setup by the ARM9 or not.
 ///


### PR DESCRIPTION
`sys/cdefs.h` is what defines `__printflike`, currently console.h relies on cdefs.h being included beforehand.
