### PR TITLE
bios: Add new swiIntrWaitAUX() for the ARM7

### DIFF
--- a/include/nds/interrupts.h
+++ b/include/nds/interrupts.h
@@ -256,6 +256,23 @@ void irqDisableAUX(u32 irq);
 ///     implemented in libnds.
 void swiIntrWait(u32 waitForSet, uint32_t flags);
 
+#ifdef ARM7
+/// Wait for interrupt(s) to occur. DSi ARM7 only.
+///
+/// @param waitForSet
+///     0: Return if the interrupt has already occured; 1: Wait until the
+///     interrupt has been set since the call
+/// @param flags
+///     Interrupt mask to wait for.
+/// @param aux_flags
+///     AUX interrupt mask to wait for.
+///
+/// @note
+///     This doesn't actually use a software interrupt, it's a custom function
+///     implemented in libnds.
+void swiIntrWaitAUX(u32 waitForSet, uint32_t flags, uint32_t aux_flags);
+#endif
+
 /// Waits for a vertical blank interrupt
 ///
 /// @note

--- a/source/arm7/intrwait.s
+++ b/source/arm7/intrwait.s
@@ -38,10 +38,46 @@ testirq:
     strb    r12, [r12, #0x208]
 
     // Acknowledge interrupt in BIOS flags register
-    ldr     r3, [r12, #-8]
+    ldr     r3, [r12, #-8] // 0x0380FFF8
     ands    r0, r1, r3
     eorne   r3, r3, r0
     strne   r3, [r12, #-8]
+
+    // REG_IME = 1
+    mov     r0, #1
+    strb    r0, [r12, #0x208]
+
+    bx      lr
+
+BEGIN_ASM_FUNC_NO_SECTION swiIntrWaitAUX
+
+    stmfd   sp!, {lr}
+    cmp     r0, #0
+    blne    testirq_aux
+
+wait_irq_aux:
+    swi     #(6 << 16) // swiHalt
+    bl      testirq_aux
+    beq     wait_irq_aux
+    ldmfd   sp!, {lr}
+    bx      lr
+
+testirq_aux:
+    // REG_IME = 0
+    mov     r12, #0x4000000
+    strb    r12, [r12, #0x208]
+
+    // Acknowledge interrupt in BIOS flags register
+    ldr     r3, [r12, #-8] // 0x0380FFF8
+    ands    r0, r1, r3
+    eorne   r3, r3, r0
+    strne   r3, [r12, #-8]
+
+    // Acknowledge interrupt in BIOS flags register
+    ldr     r3, [r12, #-0x40] // 0x0380FFC0
+    ands    r0, r2, r3
+    eorne   r3, r3, r0
+    strne   r3, [r12, #-0x40]
 
     // REG_IME = 1
     mov     r0, #1


### PR DESCRIPTION
The old prototype of swiIntrWait() doesn't support the extended interrupts of the ARM7. The prototype of swiIntrWaitAUX() supports the new flags.

However, the old prototype has been kept for compatibility with older code and so that code shared between ARM9 and ARM7 can use the same function.