### PR TITLE
palette connectCount check

### DIFF
--- a/source/arm9/video/videoGL.c
+++ b/source/arm9/video/videoGL.c
@@ -1155,7 +1155,7 @@ static void removePaletteFromTexture(gl_texture_data *tex)
         return;
 
     palette->connectCount--;
-    if (palette->connectCount > 0)
+    if (palette->connectCount <= 0)
     {
         vramBlock_deallocateBlock(glGlob.vramBlocksPal, palette->palIndex);
 


### PR DESCRIPTION
when attempting to unload a texture where the palette is assigned from another texture using glAssignColorTable(), the program crashes.

it seems that there is error when removing palette from texture. palette->connectCount should be checked if its `<= 0` instead

this resolve the issue