### PR TITLE
utf: Add simple helper to convert UTF-16LE to UTF-8

### DIFF
--- a/include/nds.h
+++ b/include/nds.h
@@ -85,6 +85,7 @@
 /// - @ref nds/decompress.h "Decompression"
 /// - @ref nds/rsa.h "DSi RSA functions"
 /// - @ref nds/sha1.h "DSi SHA1 functions"
+/// - @ref nds/utf.h "UTF functions"
 ///
 /// @section peripheral_api Custom Peripherals
 /// - @ref nds/arm9/peripherals/slot2.h "Slot-2 peripheral detection, external RAM"
@@ -151,6 +152,7 @@ extern "C" {
 #include <nds/system.h>
 #include <nds/timers.h>
 #include <nds/touch.h>
+#include <nds/utf.h>
 
 #ifdef ARM9
 #    include <nds/arm9/background.h>

--- a/include/nds/utf.h
+++ b/include/nds/utf.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2025 Antonio Niño Díaz
+
+#ifndef LIBNDS_NDS_UTF_H__
+#define LIBNDS_NDS_UTF_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @file nds/utf.h
+///
+/// @brief UTF helpers.
+///
+/// Helpers used to handle different UTF formats.
+
+#include <stddef.h>
+#include <sys/types.h>
+#include <uchar.h>
+
+#include <nds/ndstypes.h>
+
+/// It converts a UTF-16LE string to UTF-8.
+///
+/// This can be used for the firmware user setting strings, like the user name
+/// and the personal message.
+///
+/// @param out
+///     Destination buffer for the resulting string encoded as UTF-8.
+/// @param out_size
+///     Size of the destination buffer in bytes.
+/// @param in
+///     Source buffer of the UTF-16LE encoded string.
+/// @param in
+///     Size of the source buffer in bytes.
+///
+/// @result
+///     It returns the number of saved bytes in the destination buffer on
+///     success or a negative number on error. On error, the contents of the
+///     output buffer shouldn't be used.
+ssize_t utf16_to_utf8(char *out, size_t out_size, char16_t *in, size_t in_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LIBNDS_NDS_UTF_H__

--- a/source/common/utf.c
+++ b/source/common/utf.c
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (c) 2025 Antonio Niño Díaz
+
+#include <stddef.h>
+
+#include <nds/ndstypes.h>
+#include <nds/utf.h>
+
+ssize_t utf16_to_utf8(char *out, size_t out_size, char16_t *in, size_t in_size)
+{
+    ssize_t out_len = 0;
+
+    while (1)
+    {
+        char32_t codepoint;
+
+        // Decode UTF-16
+        // -------------
+
+        // https://datatracker.ietf.org/doc/html/rfc2781
+
+        if (in_size < 2)
+            break;
+
+        char16_t w1 = *in++;
+        in_size -= 2;
+
+        if ((w1 <= 0xD7FF) || (w1 >= 0xE000)) // NUL is included here
+        {
+            codepoint = w1;
+        }
+        else
+        {
+            if ((w1 >= 0xD800) && (w1 <= 0xDBFF) && (in_size >= 2))
+            {
+                char16_t w2 = *in; // Don't advance pointer yet
+                if ((w2 < 0xDC00) || (w1 > 0xDFFF))
+                {
+                    codepoint = ((w1 & 0x3FF) << 10) | (w2 & 0x3FF);
+                    in++;
+                    in_size -= 2;
+                }
+                else // Values outside of that range or NUL characters
+                {
+                    return -1;
+                }
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        // Encode UTF-8
+        // ------------
+
+        // https://en.wikipedia.org/wiki/UTF-8#Description
+
+        char utf8[4];
+        int utf8_len;
+
+        if (codepoint > 0x10FFFF)
+        {
+            return -1;
+        }
+        else if (codepoint <= 0x7F)
+        {
+            utf8[0] = codepoint & 0x7F;
+            utf8_len = 1;
+        }
+        else if (codepoint <= 0x7FF)
+        {
+            utf8[0] = 0xC0 | ((codepoint >> 6) & 0x1F);
+            utf8[1] = 0x80 | (codepoint & 0x3F);
+            utf8_len = 2;
+        }
+        else if (codepoint <= 0xFFFF)
+        {
+            utf8[0] = 0xE0 | ((codepoint >> 12) & 0xF);
+            utf8[1] = 0x80 | ((codepoint >> 6) & 0x3F);
+            utf8[2] = 0x80 | (codepoint & 0x3F);
+            utf8_len = 3;
+        }
+        else if (codepoint <= 0x10FFFF)
+        {
+            utf8[0] = 0xF0 | ((codepoint >> 18) & 0x7);
+            utf8[1] = 0x80 | ((codepoint >> 12) & 0x3F);
+            utf8[2] = 0x80 | ((codepoint >> 6) & 0x3F);
+            utf8[3] = 0x80 | (codepoint & 0x3F);
+            utf8_len = 4;
+        }
+
+        // Save to destination
+
+        for (int i = 0; i < utf8_len; i++)
+        {
+            // Increase the final string length always, but only write to the
+            // output buffer if there is space left.
+            out_len++;
+
+            if (out_size == 0)
+                break;
+
+            *out = utf8[i];
+            out++;
+            out_size--;
+        }
+
+        // Check if we've found a NUL character
+
+        if (codepoint == 0)
+            break;
+    }
+
+    return out_len;
+}


### PR DESCRIPTION
This is useful to convert the firmware user settings (user name and personal string) to a format more commonly used by libraries.