### PR TITLE
Fix potentially uninitialized variable warning

### DIFF
--- a/source/common/utf.c
+++ b/source/common/utf.c
@@ -70,11 +70,7 @@ ssize_t utf16_to_utf8(char *out, size_t out_size, char16_t *in, size_t in_size)
         char utf8[4];
         int utf8_len;
 
-        if (codepoint > 0x10FFFF)
-        {
-            return -1;
-        }
-        else if (codepoint <= 0x7F)
+        if (codepoint <= 0x7F)
         {
             utf8[0] = codepoint & 0x7F;
             utf8_len = 1;
@@ -99,6 +95,10 @@ ssize_t utf16_to_utf8(char *out, size_t out_size, char16_t *in, size_t in_size)
             utf8[2] = 0x80 | ((codepoint >> 6) & 0x3F);
             utf8[3] = 0x80 | (codepoint & 0x3F);
             utf8_len = 4;
+        }
+        else
+        {
+            return -1;
         }
 
         // Save to destination


### PR DESCRIPTION
Fixes this warning when building with LLVM:

```
libnds/source/common/utf.c:95:18: error: variable 'utf8_len' is used uninitialized whenever 'if' condition is false
        else if (codepoint <= 0x10FFFF)
                 ^~~~~~~~~~~~~~
libnds/source/common/utf.c:106:29: note: uninitialized use occurs here
        for (int i = 0; i < utf8_len; i++)
                            ^
libnds/source/common/utf.c:95:14: note: remove the 'if' if its condition is always true
        else if (codepoint <= 0x10FFFF)
             ^
```

It's a false-positive since the condition is always true, so not a bug.
