### PR TITLE
exceptions: fix non-literal format string warning

### DIFF
--- a/source/arm9/system/exceptions.c
+++ b/source/arm9/system/exceptions.c
@@ -29,7 +29,7 @@ void exceptionStatePrint(ExceptionState *ex, const char *title)
     BG_PALETTE_SUB[255] = RGB15(31, 31, 31);
 
     consoleSetCursor(NULL, (32 - strlen(title)) / 2, 0);
-    printf(title);
+    printf("%s", title);
 
     consoleSetCursor(NULL, (32 - strlen(ex->description)) / 2, 1);
     printf("%s\n\n", ex->description);


### PR DESCRIPTION
Fixes the following error generated by Clang/Zig:

```c
libnds/source/arm9/system/exceptions.c:32:12: error: format string is not a string literal (potentially insecure)
    printf(title);
           ^
libnds/source/arm9/system/exceptions.c:32:12: note: treat the string as an argument to avoid this
    printf(title);
           ^
```