### PR TITLE
math: correct semantics of asm in normalizef32()

### DIFF
--- a/source/arm9/math.c
+++ b/source/arm9/math.c
@@ -111,14 +111,14 @@ ARM_CODE void normalizef32(int32_t *a)
     register uint32_t Lo;
     register uint32_t Hi;
 
-    asm volatile (
+    asm (
         ".syntax unified \n\t"
-        "ldm %[r0], {r1,r2,r3} \n\t"
+        "ldm %[a], {r1,r2,r3} \n\t"
         "smull %[Lo],%[Hi], r1, r1 \n\t"
         "smlal %[Lo],%[Hi], r2, r2 \n\t"
         "smlal %[Lo],%[Hi], r3, r3 \n\t" :
-        [Lo]"=r&"(Lo), [Hi]"=r&"(Hi) :
-        [r0]"r"(a) :
+        [Lo]"=r"(Lo), [Hi]"=r"(Hi) :
+        [a]"r"(a), "m"(*(int32_t (*)[3]) a) :
         "r1", "r2", "r3"
     );
 


### PR DESCRIPTION
Kuratius in the gbadev Discord noticed that this asm statement was missing a memory input constraint, since it reads from the memory pointed to by `a`.

I took a look at it, too, and noticed a couple more things. `volatile` isn't necessary because the statement could be eliminated if its outputs were never used, and the `&` modifiers aren't necessary because the inputs aren't read from after the outputs are written to. I also changed the input's name to match the name of the variable instead of the name of the register it will be kept in.

None of this affects the generated code with the current toolchain, but it is a little more correct.