### PR TITLE
Ensure errno is reset in scandir so that readdir loop doesn't break early

### DIFF
--- a/source/arm9/libc/scandir.c
+++ b/source/arm9/libc/scandir.c
@@ -34,6 +34,9 @@ int scandir(const char *path, struct dirent ***names,
     if (dir == NULL)
         return -1;
 
+    // ensure errno is reset so readdir loop doesn't break early
+    errno = 0;
+
     *names = NULL;
     while ((ent = readdir(dir)) != NULL)
     {

--- a/source/arm9/libc/scandir.c
+++ b/source/arm9/libc/scandir.c
@@ -29,6 +29,10 @@ int scandir(const char *path, struct dirent ***names,
     bool error = false;
     int count = 0;
     struct dirent *ent;
+    int errno_prev;
+
+    // store original errno, to be restored if we are successful
+    errno_prev = errno;
 
     DIR *dir = opendir(path);
     if (dir == NULL)
@@ -85,5 +89,11 @@ int scandir(const char *path, struct dirent ***names,
     }
 
     closedir(dir);
+
+    // restore previous errno if no new errnos
+    if (!errno) {
+        errno = errno_prev;
+    }
+
     return error ? -1 : count;
 }


### PR DESCRIPTION
Works, but someone should probably go through the POSIX spec or other impls to see if this is the way to go tbh