### PR TITLE
readdir: Never clear errno

### DIFF
--- a/source/arm9/libc/dirent.c
+++ b/source/arm9/libc/dirent.c
@@ -137,7 +137,6 @@ struct dirent *readdir(DIR *dirp)
         if (nitrofs_readdir(dp, ent))
         {
             dirp->index = INDEX_END_OF_DIRECTORY;
-            errno = 0;
             return NULL;
         }
         else
@@ -162,7 +161,6 @@ struct dirent *readdir(DIR *dirp)
     {
         // End of directory reached
         dirp->index = INDEX_END_OF_DIRECTORY;
-        errno = 0;
         return NULL;
     }
 


### PR DESCRIPTION
As per the C23 standard draft N3088:

> The value of errno in the initial thread is zero at program startup (the initial representation of the
object designated by errno in other threads is indeterminate), but **is never set to zero by any library
function**