### PR TITLE
slot2: Distinguish between edge-activated and non-edge-activated rumble carts

### DIFF
--- a/include/nds/arm9/peripherals/slot2.h
+++ b/include/nds/arm9/peripherals/slot2.h
@@ -32,10 +32,12 @@ extern "C" {
 #define SLOT2_PERIPHERAL_GYRO_GPIO       0x00000100 ///< Gyro sensor (GPIO; WarioWare)
 #define SLOT2_PERIPHERAL_TILT            0x00000200 ///< Tilt sensor (Yoshi)
 #define SLOT2_PERIPHERAL_SOLAR_GPIO      0x00000400 ///< Solar sensor (GPIO; Boktai)
-#define SLOT2_PERIPHERAL_FACE_SCAN       0x00008000 ///< TODO: Facening Scan
+#define SLOT2_PERIPHERAL_FACE_SCAN       0x00000800 ///< TODO: Facening Scan
 #define SLOT2_PERIPHERAL_GPS_RANGER      0x00001000 ///< TODO: Ranger GPS
 #define SLOT2_PERIPHERAL_ANY             0x00001FFF
 #define SLOT2_PERIPHERAL_RUMBLE_ANY      (SLOT2_PERIPHERAL_RUMBLE_GPIO | SLOT2_PERIPHERAL_RUMBLE_PAK | SLOT2_PERIPHERAL_SLIDE_MAGKID | SLOT2_PERIPHERAL_RUMBLE_EZ)
+
+#define SLOT2_PERIPHERAL_RUMBLE_EDGE     0x00008000 ///< Rumble is edge-activated
 
 /// Initialize a Slot-2 peripheral.
 ///

--- a/source/arm9/peripherals/rumble.c
+++ b/source/arm9/peripherals/rumble.c
@@ -26,7 +26,7 @@ uint8_t rumbleGetMaxRawStrength(void)
 
 bool rumbleIsEdgeActivated(void)
 {
-    return peripheralSlot2GetSupportMask() & SLOT2_PERIPHERAL_RUMBLE_PAK;
+    return peripheralSlot2GetSupportMask() & SLOT2_PERIPHERAL_RUMBLE_EDGE;
 }
 
 #define RUMBLE_PAK_CTRL (*(vuint16 *)0x08001000)

--- a/source/arm9/peripherals/slot2.c
+++ b/source/arm9/peripherals/slot2.c
@@ -410,7 +410,7 @@ static slot2_definition_t definitions[] =
     // EZ3, EZ4, EZO, EZODE
     {
         0,
-        SLOT2_PERIPHERAL_EXTRAM | SLOT2_PERIPHERAL_RUMBLE_PAK | SLOT2_PERIPHERAL_RUMBLE_EZ,
+        SLOT2_PERIPHERAL_EXTRAM | SLOT2_PERIPHERAL_RUMBLE_PAK | SLOT2_PERIPHERAL_RUMBLE_EDGE | SLOT2_PERIPHERAL_RUMBLE_EZ,
         SLOT2_EXMEMCNT_2_1,
         0,
         ezf_detect,
@@ -419,7 +419,7 @@ static slot2_definition_t definitions[] =
     // EZF 3in1
     {
         0,
-        SLOT2_PERIPHERAL_EXTRAM | SLOT2_PERIPHERAL_RUMBLE_PAK | SLOT2_PERIPHERAL_RUMBLE_EZ,
+        SLOT2_PERIPHERAL_EXTRAM | SLOT2_PERIPHERAL_RUMBLE_PAK | SLOT2_PERIPHERAL_RUMBLE_EDGE | SLOT2_PERIPHERAL_RUMBLE_EZ,
         SLOT2_EXMEMCNT_2_1,
         0,
         ezf_detect,
@@ -464,7 +464,7 @@ static slot2_definition_t definitions[] =
     // Rumble Pak
     {
         0,
-        SLOT2_PERIPHERAL_RUMBLE_PAK,
+        SLOT2_PERIPHERAL_RUMBLE_PAK | SLOT2_PERIPHERAL_RUMBLE_EDGE,
         SLOT2_EXMEMCNT_4_2,
         0,
         pak_rumble_detect,


### PR DESCRIPTION
Non-edge-activated rumble can be driven with a bit less CPU/timer logic. The EZ Flash's status here is unknown.