### PR TITLE
math: use 64-bit intermediate for dotf32 and crossf32

### DIFF
--- a/include/nds/arm9/math.h
+++ b/include/nds/arm9/math.h
@@ -451,9 +451,9 @@ ARM_CODE float hw_sqrtf(float x);
 ///     Result pointer to fixed 3x3 matrix
 static inline void crossf32(int32_t *a, int32_t *b, int32_t *result)
 {
-    result[0] = mulf32(a[1], b[2]) - mulf32(b[1], a[2]);
-    result[1] = mulf32(a[2], b[0]) - mulf32(b[2], a[0]);
-    result[2] = mulf32(a[0], b[1]) - mulf32(b[0], a[1]);
+    result[0] = ((int64_t)a[1]*b[2] + (int64_t)-b[1]*a[2])>>12;
+    result[1] = ((int64_t)a[2]*b[0] + (int64_t)-b[2]*a[0])>>12;
+    result[2] = ((int64_t)a[0]*b[1] + (int64_t)-b[0]*a[1])>>12;
 }
 
 /// 20.12 fixed point dot product.
@@ -471,7 +471,7 @@ static inline void crossf32(int32_t *a, int32_t *b, int32_t *result)
 ///     32 bit integer result
 static inline int32_t dotf32(int32_t *a, int32_t *b)
 {
-    return mulf32(a[0], b[0]) + mulf32(a[1], b[1]) + mulf32(a[2], b[2]);
+    return ((int64_t)a[0]*b[0]+(int64_t)a[1]*b[1]+(int64_t)a[2]*b[2])>>12;
 }
 
 /// 20.12 fixed point normalize (set magnitude to 1.0 and keep the direction).


### PR DESCRIPTION
Except for INT32_MIN*1 inputs this increases accuracy in all cases. It also improves performance and code size due to using smlal.

c.f. https://godbolt.org/z/of6E8h3qn


Out of these two, crossf32 is the one where INT32_MIN can be problematic. 
Edit: I cant seem to trigger this issue for some reason, but I believe since the bit pattern for the additive inverse of INT32_MIN is identical to (uint32_t)INT32_MIN I think it should be an issue for smull.

