### PR TITLE
Add SDMMC_getCidRaw

### DIFF
--- a/include/nds/arm7/sdmmc.h
+++ b/include/nds/arm7/sdmmc.h
@@ -189,7 +189,7 @@ u32 SDMMC_importDevState(const u8 devNum, const u8 devIn[64]);
 ///     Returns SDMMC_ERR_NONE on success or SDMMC_ERR_INVAL_PARAM on failure.
 u32 SDMMC_getDevInfo(const u8 devNum, SdmmcInfo *const infoOut);
 
-/// Outputs the CID of a (e)MMC/SD card device.
+/// Outputs the parsed CID of a (e)MMC/SD card device, in the format used by other OSes and drivers.
 ///
 /// @param devNum
 ///     The device.
@@ -199,6 +199,18 @@ u32 SDMMC_getDevInfo(const u8 devNum, SdmmcInfo *const infoOut);
 /// @return
 ///     Returns SDMMC_ERR_NONE on success or SDMMC_ERR_INVAL_PARAM on failure.
 u32 SDMMC_getCid(const u8 devNum, u32 cidOut[4]);
+
+/// Outputs the raw CID of a (e)MMC/SD card device, as it is returned from the sdmmc controller.
+/// This is the format used for the DSi NAND crypto.
+///
+/// @param devNum
+///     The device.
+/// @param cidOut
+///     A u32[4] pointer for storing the raw CID.
+///
+/// @return
+///     Returns SDMMC_ERR_NONE on success or SDMMC_ERR_INVAL_PARAM on failure.
+u32 SDMMC_getCidRaw(const u8 devNum, u32 cidOut[4]);
 
 /// Returns the SDMMC_STATUS bits of a (e)MMC/SD card device.
 ///

--- a/source/arm7/storage/sdmmc.twl.c
+++ b/source/arm7/storage/sdmmc.twl.c
@@ -649,6 +649,24 @@ u32 SDMMC_getCid(const u8 devNum, u32 cidOut[4])
     return SDMMC_ERR_NONE;
 }
 
+u32 SDMMC_getCidRaw(const u8 devNum, u32 cidOut[4])
+{
+	u32 cidFixed[4];
+	u32 err = SDMMC_getCid(devNum, cidFixed);
+    if (err != SDMMC_ERR_NONE)
+		return err;
+
+	if (cidOut != NULL)
+	{
+		cidOut[0] = (cidFixed[3] >> 8) | (cidFixed[2] << 24);
+		cidOut[1] = (cidFixed[2] >> 8) | (cidFixed[1] << 24);
+		cidOut[2] = (cidFixed[1] >> 8) | (cidFixed[0] << 24);
+		cidOut[3] = (cidFixed[0] >> 8);
+	}
+
+    return SDMMC_ERR_NONE;
+}
+
 u8 SDMMC_getDiskStatus(const u8 devNum)
 {
     if (devNum > SDMMC_MAX_DEV_NUM)


### PR DESCRIPTION
The function SDMMC_getCid returns the CID of the mmc/sd flash properly parsed in the format used by other Operating Systems and drivers, which closely match the specification. Since the only purpose for the CID on the DSi is for NAND crypto, and that part uses the raw CID returned by the hardware without any fixup, this function is added to return the "unfixed" CID to be used directly in NAND crypto operations