### PR TITLE
math: Add restrict qualifier to result in crossf32

### DIFF
--- a/include/nds/arm9/math.h
+++ b/include/nds/arm9/math.h
@@ -449,7 +449,7 @@ ARM_CODE float hw_sqrtf(float x);
 ///     Pointer to fixed 3 dimensions vector.
 /// @param result
 ///     Pointer to fixed 3 dimensions vector that will contain the result.
-static inline void crossf32(const int32_t *a, const int32_t *b, int32_t *result)
+__attribute__((always_inline)) static inline void crossf32(const int32_t *a, const int32_t *b, int32_t *result)
 {
     if(__builtin_constant_p(a[0]) && __builtin_constant_p(b[0]) &&
        __builtin_constant_p(a[1]) && __builtin_constant_p(b[1]) &&

--- a/include/nds/arm9/math.h
+++ b/include/nds/arm9/math.h
@@ -449,7 +449,7 @@ ARM_CODE float hw_sqrtf(float x);
 ///     Pointer to fixed 3 dimensions vector.
 /// @param result
 ///     Pointer to fixed 3 dimensions vector that will contain the result.
-void crossf32(int32_t *a, int32_t *b, int32_t *result);
+void crossf32(const int32_t *a, const int32_t *b, int32_t *result);
 
 /// 20.12 fixed point dot product.
 ///

--- a/include/nds/arm9/math.h
+++ b/include/nds/arm9/math.h
@@ -449,7 +449,7 @@ ARM_CODE float hw_sqrtf(float x);
 ///     Pointer to fixed 3 dimensions vector.
 /// @param result
 ///     Pointer to fixed 3 dimensions vector that will contain the result.
-static inline void crossf32(int32_t *a, int32_t *b, int32_t *result)
+static inline void crossf32(int32_t *a, int32_t *b, int32_t *restrict result)
 {
     result[0] = ((int64_t)a[1] * b[2] + (int64_t)-b[1] * a[2]) >> 12;
     result[1] = ((int64_t)a[2] * b[0] + (int64_t)-b[2] * a[0]) >> 12;

--- a/include/nds/arm9/math.h
+++ b/include/nds/arm9/math.h
@@ -449,12 +449,7 @@ ARM_CODE float hw_sqrtf(float x);
 ///     Pointer to fixed 3 dimensions vector.
 /// @param result
 ///     Pointer to fixed 3 dimensions vector that will contain the result.
-static inline void crossf32(int32_t *a, int32_t *b, int32_t *restrict result)
-{
-    result[0] = ((int64_t)a[1] * b[2] + (int64_t)-b[1] * a[2]) >> 12;
-    result[1] = ((int64_t)a[2] * b[0] + (int64_t)-b[2] * a[0]) >> 12;
-    result[2] = ((int64_t)a[0] * b[1] + (int64_t)-b[0] * a[1]) >> 12;
-}
+void crossf32(int32_t *a, int32_t *b, int32_t *result);
 
 /// 20.12 fixed point dot product.
 ///

--- a/include/nds/arm9/math.h
+++ b/include/nds/arm9/math.h
@@ -449,27 +449,7 @@ ARM_CODE float hw_sqrtf(float x);
 ///     Pointer to fixed 3 dimensions vector.
 /// @param result
 ///     Pointer to fixed 3 dimensions vector that will contain the result.
-__attribute__((always_inline)) static inline void crossf32(const int32_t *a, const int32_t *b, int32_t *result)
-{
-    if(__builtin_constant_p(a[0]) && __builtin_constant_p(b[0]) &&
-       __builtin_constant_p(a[1]) && __builtin_constant_p(b[1]) &&
-       __builtin_constant_p(a[2]) && __builtin_constant_p(b[2]))
-    {
-        int32_t ta[3]={a[0],a[1],a[2]};
-        int32_t tb[3]={b[0],b[1],b[2]};
-        tb[1]=-tb[1];
-        result[0] = ((int64_t)ta[1]*tb[2] + (int64_t)tb[1]*ta[2])>>12;
-        ta[0]=-ta[0];
-        result[1] = ((int64_t)ta[2]*tb[0] + (int64_t)tb[2]*ta[0])>>12;
-        tb[0]=-tb[0];
-        result[2] = ((int64_t)ta[0]*tb[1] + (int64_t)tb[0]*ta[1])>>12;
-        //the weird minus signs are to keep it fully identical to the asm code
-        return;
-    }
-    ARM_CODE void libnds_asm_crossf32(const int32_t *a,const int32_t * b,int32_t *result);
-    libnds_asm_crossf32(a,b,result);
-    return;
-}
+ARM_CODE void crossf32(const int32_t *a, const int32_t *b, int32_t *result);
 
 /// 20.12 fixed point dot product.
 ///

--- a/include/nds/arm9/math.h
+++ b/include/nds/arm9/math.h
@@ -466,8 +466,8 @@ static inline void crossf32(const int32_t *a, const int32_t *b, int32_t *result)
         //the weird minus signs are to keep it fully identical to the asm code
         return;
     }
-    ARM_CODE void asm_crossf32(const int32_t *a,const int32_t * b,int32_t *result);
-    asm_crossf32(a,b,result);
+    ARM_CODE void libnds_asm_crossf32(const int32_t *a,const int32_t * b,int32_t *result);
+    libnds_asm_crossf32(a,b,result);
     return;
 }
 

--- a/include/nds/arm9/math.h
+++ b/include/nds/arm9/math.h
@@ -449,7 +449,27 @@ ARM_CODE float hw_sqrtf(float x);
 ///     Pointer to fixed 3 dimensions vector.
 /// @param result
 ///     Pointer to fixed 3 dimensions vector that will contain the result.
-void crossf32(const int32_t *a, const int32_t *b, int32_t *result);
+static inline void crossf32(const int32_t *a, const int32_t *b, int32_t *result)
+{
+    if(__builtin_constant_p(a[0]) && __builtin_constant_p(b[0]) &&
+       __builtin_constant_p(a[1]) && __builtin_constant_p(b[1]) &&
+       __builtin_constant_p(a[2]) && __builtin_constant_p(b[2]))
+    {
+        int32_t ta[3]={a[0],a[1],a[2]};
+        int32_t tb[3]={b[0],b[1],b[2]};
+        tb[1]=-tb[1];
+        result[0] = ((int64_t)ta[1]*tb[2] + (int64_t)tb[1]*ta[2])>>12;
+        ta[0]=-ta[0];
+        result[1] = ((int64_t)ta[2]*tb[0] + (int64_t)tb[2]*ta[0])>>12;
+        tb[0]=-tb[0];
+        result[2] = ((int64_t)ta[0]*tb[1] + (int64_t)tb[0]*ta[1])>>12;
+        //the weird minus signs are to keep it fully identical to the asm code
+        return;
+    }
+    ARM_CODE void asm_crossf32(const int32_t *a,const int32_t * b,int32_t *result);
+    asm_crossf32(a,b,result);
+    return;
+}
 
 /// 20.12 fixed point dot product.
 ///

--- a/source/arm9/math.c
+++ b/source/arm9/math.c
@@ -172,7 +172,7 @@ ARM_CODE void normalizef32(int32_t *a)
     }
 }
 
-ARM_CODE void asm_crossf32(const int32_t *a,const int32_t * b,int32_t *result)
+ARM_CODE void libnds_asm_crossf32(const int32_t *a,const int32_t * b,int32_t *result)
 {
     register const int32_t *r0 asm("r0")=a;
     asm (

--- a/source/arm9/math.c
+++ b/source/arm9/math.c
@@ -172,7 +172,7 @@ ARM_CODE void normalizef32(int32_t *a)
     }
 }
 
-ARM_CODE void crossf32(int32_t *a, int32_t *b, int32_t *result)
+ARM_CODE void crossf32(const int32_t *a,const int32_t *b, int32_t *result)
 {
     int32_t ta[3]={a[0],a[1],a[2]};
     int32_t tb[3]={b[0],b[1],b[2]};

--- a/source/arm9/math.c
+++ b/source/arm9/math.c
@@ -171,3 +171,12 @@ ARM_CODE void normalizef32(int32_t *a)
         a[i] = prod;
     }
 }
+
+ARM_CODE void crossf32(int32_t *a, int32_t *b, int32_t *result)
+{
+    int32_t ta[3]={a[0],a[1],a[2]};
+    int32_t tb[3]={b[0],b[1],b[2]};
+    result[0] = ((int64_t)ta[1] * tb[2] + (int64_t)-tb[1] * ta[2]) >> 12;
+    result[1] = ((int64_t)ta[2] * tb[0] + (int64_t)-tb[2] * ta[0]) >> 12;
+    result[2] = ((int64_t)ta[0] * tb[1] + (int64_t)-tb[0] * ta[1]) >> 12;
+}

--- a/source/arm9/math.c
+++ b/source/arm9/math.c
@@ -172,11 +172,37 @@ ARM_CODE void normalizef32(int32_t *a)
     }
 }
 
-ARM_CODE void crossf32(const int32_t *a,const int32_t *b, int32_t *result)
+ARM_CODE void asm_crossf32(const int32_t *a,const int32_t * b,int32_t *result)
 {
-    int32_t ta[3]={a[0],a[1],a[2]};
-    int32_t tb[3]={b[0],b[1],b[2]};
-    result[0] = ((int64_t)ta[1] * tb[2] + (int64_t)-tb[1] * ta[2]) >> 12;
-    result[1] = ((int64_t)ta[2] * tb[0] + (int64_t)-tb[2] * ta[0]) >> 12;
-    result[2] = ((int64_t)ta[0] * tb[1] + (int64_t)-tb[0] * ta[1]) >> 12;
+    register const int32_t *r0 asm("r0")=a;
+    asm (
+        ".syntax unified                  \n\t"
+        //load vectors
+        "ldm %[b],{r6,r12,lr}             \n\t"
+        "ldm %[r0],{r3,r4,r5}             \n\t"
+        //first component
+        "rsb   r12,r12,#0                 \n\t"
+        "smull %[r0],%[b], r4, lr         \n\t"
+        "smlal %[r0],%[b], r12, r5        \n\t"
+        "lsr   %[r0],%[r0], #12           \n\t"
+        "orr   %[r0],%[r0],%[b],lsl #20   \n\t"
+        //second component
+        "rsb   r3,r3,#0                   \n\t"
+        "smull r5,%[b], r6, r5            \n\t"
+        "smlal r5,%[b], lr, r3            \n\t"
+        "lsr   r5, r5, #12                \n\t"
+        "orr   r5,r5, %[b], lsl #20       \n\t"
+        //third component
+        "rsb   r6,r6, #0                  \n\t"
+        "smull lr,%[b], r3, r12           \n\t"
+        "smlal lr,%[b], r4, r6            \n\t"
+        "lsr lr, lr, #12                  \n\t"
+        "orr lr,lr, %[b], lsl #20         \n\t"
+        //store result
+        "stm %[result], {%[r0],r5,lr}"
+/*outputs*/:"=m"(*(int32_t (*)[3]) result),[r0]"+r"(r0),[b]"+r"(b)
+/*inputs*/ :[result]"r"(result),"m"(*(int32_t (*)[3]) r0),  "m"(*(int32_t (*)[3]) b)
+/*clobber*/:"r3", "r4", "r5","r6", "r12", "lr"
+    );
+    return;
 }


### PR DESCRIPTION
This allows tighter code generation in some cases.


https://godbolt.org/z/bnqnzobPf

Edit: Apparently thumb gets larger though.

Size in arm:
24 instructions (96 bytes) with restrict
35 instructions (140 bytes) without restrict

Size in thumb:
72 instructions without restrict (144 bytes)
97 instructions with restrict (196 bytes)
