### PR TITLE
input: Fix regression causing keysDownRepeat not report keys on their first press

### DIFF
--- a/source/arm9/system/keys.c
+++ b/source/arm9/system/keys.c
@@ -75,7 +75,7 @@ void scanKeys(void)
         if (keys != keysold)
         {
             count = delay;
-            keysrepeat = keysDown();
+            keysrepeat = (keys & ~keysold);
         }
         count--;
         if (count == 0)


### PR DESCRIPTION
In a previous optimization commit, the behaviour of keysDownRepeat changed.
The state of held keys is updated in `scanKeys`, which calls `keysDown` internally to build the mask of held keys, but that function after the optimization is currently returning the previously cached values which don't reflect the keys being pressed at the moment of `scanKeys` being called.