### PR TITLE
card: rebrand CARD_CR1_* as a macro of CARD_SPICNTH_*

### DIFF
--- a/include/nds/card.h
+++ b/include/nds/card.h
@@ -35,9 +35,6 @@ extern "C" {
 #define REG_CARD_1B8 (*(vu16 *)0x040001B8)
 #define REG_CARD_1BA (*(vu16 *)0x040001BA)
 
-#define CARD_CR1_ENABLE 0x80 // In byte 1, i.e. 0x8000
-#define CARD_CR1_IRQ    0x40 // In byte 1, i.e. 0x4000
-
 // SPI EEPROM COMMANDS
 #define SPI_EEPROM_WRSR 0x01
 #define SPI_EEPROM_PP   0x02 // Page Program
@@ -95,6 +92,9 @@ extern "C" {
 
 #define CARD_SPICNTH_ENABLE  (1 << 7) // In byte 1, i.e. 0x8000
 #define CARD_SPICNTH_IRQ     (1 << 6) // In byte 1, i.e. 0x4000
+
+#define CARD_CR1_ENABLE CARD_SPICNTH_ENABLE // In byte 1, i.e. 0x8000
+#define CARD_CR1_IRQ    CARD_SPICNTH_IRQ    // In byte 1, i.e. 0x4000
 
 /// Enable Slot-1 in a DSi console.
 void enableSlot1(void);

--- a/source/common/card.c
+++ b/source/common/card.c
@@ -17,7 +17,7 @@
 
 void cardWriteCommand(const u8 *command)
 {
-    REG_AUXSPICNTH = CARD_CR1_ENABLE | CARD_CR1_IRQ;
+    REG_AUXSPICNTH = CARD_SPICNTH_ENABLE | CARD_SPICNTH_IRQ;
 
     for (int index = 0; index < 8; index++)
         REG_CARD_COMMAND[7 - index] = command[index];
@@ -89,7 +89,7 @@ void cardReadHeader(u8 *header)
 
     swiDelay(167550);
 
-    REG_AUXSPICNTH = CARD_CR1_ENABLE | CARD_CR1_IRQ;
+    REG_AUXSPICNTH = CARD_SPICNTH_ENABLE | CARD_SPICNTH_IRQ;
     REG_ROMCTRL = CARD_nRESET | CARD_SEC_SEED;
 
     while (REG_ROMCTRL & CARD_BUSY);


### PR DESCRIPTION
This aligns with the renaming of the CARD_CR1 register to REG_AUXSPICNT as of libnds commit e2a8242acde78c2fa65b467e799c3b96d841af52.

The original name is also a misnomer as this macro is intended to be applied to REG_AUXSPICNTH (the higher 1 byte of REG_AUXSPICNT), which was actually named CARD_CR1H previously.