### PR TITLE
nand: ensure crypto is initialized when a read/write command is issued

### DIFF
--- a/include/nds/arm7/nand_crypto.h
+++ b/include/nds/arm7/nand_crypto.h
@@ -23,6 +23,12 @@ extern "C" {
 /// required to perform cryptographic operations on the NAND.
 void nandCrypt_Init(void);
 
+/// Checks if nand crypto initialization has been performed.
+///
+/// @return
+///     If the AES keyslots were initialized, returns true.
+bool nandCrypt_Initialized(void);
+
 /// Sets the Input Vector in the aes engine to crypt the NAND blocks.
 ///
 /// @param offset

--- a/source/arm7/storage/nand_crypto.twl.c
+++ b/source/arm7/storage/nand_crypto.twl.c
@@ -10,9 +10,14 @@
 static u8 nand_ctr_iv[16] = {0};
 static const u8 empty[16] = {0};
 
+void nandCrypt_Initialized(void)
+{
+    return memcmp(empty, nand_ctr_iv, 16) != 0;
+}
+
 void nandCrypt_Init(void)
 {
-    if (memcmp(empty, nand_ctr_iv, 16) != 0)
+    if (nandCrypt_Initialized())
         return;
 
     // "Activate" the key Y to generate the normal key

--- a/source/arm7/storage/storage_fifo.twl.c
+++ b/source/arm7/storage/storage_fifo.twl.c
@@ -216,6 +216,9 @@ static u32 sdmmcReadSectors(const u8 devNum, u32 sect, u8 *buf, u32 count, bool 
     u32 result;
     const bool word_aligned = IS_WORD_ALIGNED(buf);
 
+    if (crypt && !nandCrypt_Initialized())
+        return SDMMC_ERR_LOCKED;
+
 #ifdef NDMA_CHANNEL
     if (crypt)
     {
@@ -272,6 +275,9 @@ static u32 sdmmcReadSectors(const u8 devNum, u32 sect, u8 *buf, u32 count, bool 
 static u32 sdmmcWriteSectors(const u8 devNum, u32 sect, const u8 *buf, u32 count, bool crypt)
 {
     u32 result;
+
+    if (crypt && !nandCrypt_Initialized())
+        return SDMMC_ERR_LOCKED;
 
 #ifdef NDMA_CHANNEL
     if (crypt)


### PR DESCRIPTION
This adds an extra check when the arm9 tries to read/write crypted blocks to the DSi nand, ensuring that a call to `nandCrypt_Init` has been done beforehand (in case the ReadCrypt/WriteCrypt functions are called manually by the program without using fatfs)